### PR TITLE
introduce "envelope" class to instantiate MicroDAQ more easily

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,8 @@ option(ENABLE_TESTING "Build tests" ON)
 #______________________________________________________________________________
 #                                                                       VERSION
 set(${PROJECT_NAME}_MAJOR_VERSION 01)
-set(${PROJECT_NAME}_MINOR_VERSION 00)
-set(${PROJECT_NAME}_PATCH_VERSION 03)
+set(${PROJECT_NAME}_MINOR_VERSION 01)
+set(${PROJECT_NAME}_PATCH_VERSION 00)
 include(${CMAKE_SOURCE_DIR}/cmake/set_version_numbers.cmake)
 
 include(${CMAKE_SOURCE_DIR}/cmake/set_default_flags.cmake)
@@ -22,7 +22,7 @@ include(${CMAKE_SOURCE_DIR}/cmake/set_default_build_to_release.cmake)
 #______________________________________________________________________________
 #                                                                  Dependencies
 include(cmake/add_dependency.cmake)
-add_dependency(ChimeraTK-ApplicationCore 01.00 REQUIRED)
+add_dependency(ChimeraTK-ApplicationCore 02.02 REQUIRED)
 
 IF(ENABLE_HDF5)
   FIND_PACKAGE(HDF5 REQUIRED COMPONENTS C CXX HL)
@@ -109,7 +109,7 @@ if(Boost_UNIT_TEST_FRAMEWORK_FOUND AND ENABLE_TESTING)
     add_executable(test_ScalarMicroDAQ test/testScalarMicroDAQ.C)
     target_link_libraries(test_ScalarMicroDAQ ${PROJECT_NAME} ROOT::Tree)
     set_target_properties(test_ScalarMicroDAQ PROPERTIES COMPILE_FLAGS "${ChimeraTK-ApplicationCore_CXX_FLAGS}"
-                                                        LINK_FLAGS "${ChimeraTK-ApplicationCore_LINKER_FLAGS}")
+                                                         LINK_FLAGS "${ChimeraTK-ApplicationCore_LINKER_FLAGS}")
     add_test( test_ScalarMicroDAQ test_ScalarMicroDAQ)                         
                               
     add_executable(test_ArrayMicroDAQ test/testArrayMicroDAQ.C)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,17 +56,18 @@ ENDIF(ENABLE_ROOT)
 set(source_MicroDAQ src/MicroDAQ.cc)
 SET(daq_header include/MicroDAQ.h)
 
-IF(ENABLE_HDF5 )
+IF(ENABLE_HDF5)
   # Append MicroDAQ based on HDF5
   list(APPEND source_MicroDAQ src/MicroDAQHDF5.cc)
   string(APPEND daq_header ";include/MicroDAQHDF5.h") 
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DENABLE_HDF5")
 ENDIF(ENABLE_HDF5)
 
 IF(ENABLE_ROOT)
   string(APPEND daq_header ";include/MicroDAQROOT.h;include/data_types.h")
   # Append MicroDAQ based on ROOT
-  list(APPEND source_MicroDAQ src/MicroDAQROOT.cc
-                                 ${ROOTDICTDAQ})
+  list(APPEND source_MicroDAQ src/MicroDAQROOT.cc ${ROOTDICTDAQ})
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DENABLE_ROOT")
 ENDIF(ENABLE_ROOT)
 
 # Build library that contains the MicroDAQ module to be used in ChimeraTK

--- a/README.md
+++ b/README.md
@@ -7,15 +7,36 @@ Currently two DAQ backends are implemented:
 * `ChimeraTK::HDF5DAQ`: HDF5 based DAQ that uses uncompressed HDF5 files.
 * `ChimeraTK::ROOTDAQ`: ROOT based DAQ that uses compressed ROOT files.
 
-The provided modules include configuration and status  process variables that can be connected to the control system using the following tags:
-
-* `MicroDAQ.CONFIG`: Configuration of the DAQ system, like enable, buffer size, triggers per buffer
-* `MicroDAQ.STATUS`: Error flag indicating problems of the DAQ, current DAQ path, current buffer and current DAQ entry
-
+The provided modules include configuration and status process variables. DAQ problems are indicated by the process variable `DAQError`. 
 In case of DAQ errors just disable and reenable the DAQ once.
 
-
 The idea to use ROOT files instead of HDF5 files is to reduce the file size and improve the analysis performance, especially when working with many large files.  
+
+## Envelope class
+
+The envelope class `MicroDAQ` can used to include the DAQ into a server, while allowing to configure the daq via the server config file. 
+In the config file, the following variables are required:
+
+* MicroDAQ/enable (int32): boolean flag whether the MicroDAQ system is enabled or not
+* MicroDAQ/outputFormat (string): format of the output data, either "hdf5" or "root"
+* MicroDAQ/decimationFactor (uint32): decimation factor applied to large arrays (above decimationThreshold)
+* MicroDAQ/decimationThreshold (uint32): array size threshold above which the decimationFactor is applied
+
+If `MicroDAQ/enable == 0`, all other variables can be omitted.
+
+In order to use the envelope class the `MicroDAQ` class needs to be defined after the `ChimeraTK::ConfigReader` in the server application. The `MicroDAQ` consturctor takes an `inputTag`, which is used to identify
+variables of other modules that should be connected to the DAQ module. The `tags` passed in constructor of `MicroDAQ` will be added to all process variables of the 
+daq. If you add e.g. `"CS"` you can connect all process variables of the daq to the control system by using a universal method call: 
+
+      findTag("CS").connectTo(cs);
+      
+
+
+## Remark on DeviceModules
+
+It is possible to connect DeviceModules to the DAQ. This requires to connect them to the ControlSystem fist and after connect the corresponing control system part to the 
+daq using the `addSource` method. That is currently not possible using the envelope class, because it requires a certain tag to identify the daq variables and currently 
+it is not possible to add tags to the DeviceModule. 
 
 ## Remark on data types
 

--- a/include/MicroDAQ.h
+++ b/include/MicroDAQ.h
@@ -210,8 +210,6 @@ namespace ChimeraTK {
       ScalarPushInput<TRIGGERTYPE> trigger;
     } triggerGroup;
 
-    VariableNetworkNode trigger{triggerGroup.trigger};
-
     ScalarPollInput<std::string> setPath { this, "directory", "",
         "Directory where to store the DAQ data. If not set a subdirectory called uDAQ in the current directory is used.",
         _tags };

--- a/include/MicroDAQ.h
+++ b/include/MicroDAQ.h
@@ -50,7 +50,7 @@ namespace ChimeraTK {
      *  - MicroDAQ/enable (int32): boolean flag whether the MicroDAQ system is enabled or not
      *  - MicroDAQ/outputFormat (string): format of the output data, either "hdf5" or "root"
      *  - MicroDAQ/decimationFactor (uint32): decimation factor applied to large arrays (above decimationThreshold)
-     *  - MicroDAQ/decimationThreshold (uint32): array size threshold above wich the decimationFactor is applied
+     *  - MicroDAQ/decimationThreshold (uint32): array size threshold above which the decimationFactor is applied
      *
      *  If MicroDAQ/enable == 0, all other variables can be omitted.
      */
@@ -185,7 +185,7 @@ namespace ChimeraTK {
           _decimationThreshold(decimationThreshold),
           _daqDefaultPath((boost::filesystem::current_path()/"uDAQ").string()),
           _suffix(suffix),
-          _tags(addCompatibilityTag(tags)),
+          _tags(tags),
           triggerGroup(this, pathToTrigger[0] != '/' ? "./"+pathToTrigger : pathToTrigger, tags)
     {}
 
@@ -194,11 +194,6 @@ namespace ChimeraTK {
     {}
 
   private:
-
-    std::unordered_set<std::string> addCompatibilityTag(std::unordered_set<std::string> tags) {
-      tags.insert("MicroDAQ.CONFIG");
-      return tags;
-    }
 
     std::unordered_set<std::string> _tags; ///< Tags to be added to all variables of the DAQ module.
 

--- a/include/MicroDAQ.h
+++ b/include/MicroDAQ.h
@@ -200,7 +200,7 @@ namespace ChimeraTK {
       return tags;
     }
 
-    std::unordered_set<std::string> _tags;
+    std::unordered_set<std::string> _tags; ///< Tags to be added to all variables of the DAQ module.
 
   public:
 

--- a/include/MicroDAQHDF5.h
+++ b/include/MicroDAQHDF5.h
@@ -41,13 +41,15 @@ namespace ChimeraTK {
      * before writing to the HDF5 file.
      */
     HDF5DAQ(EntityOwner* owner, const std::string& name, const std::string& description,
-        uint32_t decimationFactor = 10, uint32_t decimationThreshold = 1000, HierarchyModifier hierarchyModifier = HierarchyModifier::none,
-        const std::unordered_set<std::string>& tags = {})
-    : BaseDAQ<TRIGGERTYPE>(owner, name, description, ".h5", decimationFactor, decimationThreshold, hierarchyModifier, tags) {}
+        uint32_t decimationFactor = 10, uint32_t decimationThreshold = 1000,
+        HierarchyModifier hierarchyModifier = HierarchyModifier::none,
+        const std::unordered_set<std::string>& tags = {}, const std::string &pathToTrigger="trigger")
+    : BaseDAQ<TRIGGERTYPE>(owner, name, description, ".h5", decimationFactor, decimationThreshold, hierarchyModifier,
+                           tags, pathToTrigger) {}
 
     /** Default constructor, creates a non-working module. Can be used for late
      * initialisation. */
-    HDF5DAQ() :  BaseDAQ<TRIGGERTYPE>()  {}
+    HDF5DAQ() : BaseDAQ<TRIGGERTYPE>()  {}
 
     /**
      * Overload that calls virtualiseFromCatalog.

--- a/include/MicroDAQROOT.h
+++ b/include/MicroDAQROOT.h
@@ -46,14 +46,16 @@ namespace ChimeraTK {
       RootDAQ(EntityOwner* owner, const std::string& name, const std::string& description,
              uint32_t decimationFactor = 10, uint32_t decimationThreshold = 1000, HierarchyModifier hierarchyModifier = HierarchyModifier::none,
              const std::unordered_set<std::string>& tags = {}, const std::string &pathToTrigger="trigger")
-             : BaseDAQ<TRIGGERTYPE>(owner, name, description, ".root", decimationFactor, decimationThreshold, hierarchyModifier, tags, pathToTrigger) {}
+             : BaseDAQ<TRIGGERTYPE>(owner, name, description, ".root", decimationFactor, decimationThreshold, hierarchyModifier, tags, pathToTrigger) {
+        flushAfterNEntries.addTags(tags);
+      }
 
      /** Default constructor, creates a non-working module. Can be used for late
       * initialisation. */
      RootDAQ() : BaseDAQ<TRIGGERTYPE>() {}
 
      ScalarPollInput<uint32_t> flushAfterNEntries { this, "flushAfterNEntries", "",
-         "Number of entries to be accumulated before writing to file. This is ignored if value is 0.", { "MicroDAQ.CONFIG" } };
+         "Number of entries to be accumulated before writing to file. This is ignored if value is 0."};
 
     protected:
      void mainLoop() override;

--- a/include/MicroDAQROOT.h
+++ b/include/MicroDAQROOT.h
@@ -45,8 +45,8 @@ namespace ChimeraTK {
       */
       RootDAQ(EntityOwner* owner, const std::string& name, const std::string& description,
              uint32_t decimationFactor = 10, uint32_t decimationThreshold = 1000, HierarchyModifier hierarchyModifier = HierarchyModifier::none,
-             const std::unordered_set<std::string>& tags = {})
-             : BaseDAQ<TRIGGERTYPE>(owner, name, description, ".root", decimationFactor, decimationThreshold, hierarchyModifier, tags) {}
+             const std::unordered_set<std::string>& tags = {}, const std::string &pathToTrigger="trigger")
+             : BaseDAQ<TRIGGERTYPE>(owner, name, description, ".root", decimationFactor, decimationThreshold, hierarchyModifier, tags, pathToTrigger) {}
 
      /** Default constructor, creates a non-working module. Can be used for late
       * initialisation. */

--- a/src/MicroDAQ.cc
+++ b/src/MicroDAQ.cc
@@ -32,7 +32,7 @@ namespace ChimeraTK {
   MicroDAQ<TRIGGERTYPE>::MicroDAQ(EntityOwner* owner, const std::string& name, const std::string& description,
       const std::string& inputTag,  const std::string& pathToTrigger, HierarchyModifier hierarchyModifier,
       const std::unordered_set<std::string>& tags)
-  : ModuleGroup(owner, name, "", HierarchyModifier::hideThis, tags)
+  : ModuleGroup(owner, name, "", HierarchyModifier::hideThis)
   {
     // do nothing if the entire module is disabled
     if(appConfig().template get<int>("MicroDAQ/enable") == false) return;

--- a/src/MicroDAQHDF5.cc
+++ b/src/MicroDAQHDF5.cc
@@ -111,7 +111,7 @@ namespace ChimeraTK {
     // loop: process incoming triggers
     auto group = ApplicationModule::readAnyGroup();
     while(true) {
-      group.readUntil(BaseDAQ<TRIGGERTYPE>::trigger.getId());
+      group.readUntil(BaseDAQ<TRIGGERTYPE>::triggerGroup.trigger.getId());
       storage.processTrigger();
     }
   }

--- a/src/MicroDAQROOT.cc
+++ b/src/MicroDAQROOT.cc
@@ -268,7 +268,7 @@ namespace ChimeraTK {
     // loop: process incoming triggers
     auto group = ApplicationModule::readAnyGroup();
     while(true) {
-      group.readUntil(BaseDAQ<TRIGGERTYPE>::trigger.getId());
+      group.readUntil(BaseDAQ<TRIGGERTYPE>::triggerGroup.trigger.getId());
       storage.processTrigger();
     }
   }


### PR DESCRIPTION
New MicroDAQ class for more easy instantiation:
* Takes configuration directly from XML config file
* No need to deal with HDF5 vs. ROOT in application
* "Modern" ApplicationCore: No need to configure module after instantiation. Tag to search for and path name of trigger variable passed to constructor.

This should only add functionality and not destroy anything currently working.