### PR TITLE
fix PVs connected to wrong places

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ option(ENABLE_TESTING "Build tests" ON)
 #                                                                       VERSION
 set(${PROJECT_NAME}_MAJOR_VERSION 01)
 set(${PROJECT_NAME}_MINOR_VERSION 01)
-set(${PROJECT_NAME}_PATCH_VERSION 01)
+set(${PROJECT_NAME}_PATCH_VERSION 02)
 include(${CMAKE_SOURCE_DIR}/cmake/set_version_numbers.cmake)
 
 include(${CMAKE_SOURCE_DIR}/cmake/set_default_flags.cmake)
@@ -22,7 +22,7 @@ include(${CMAKE_SOURCE_DIR}/cmake/set_default_build_to_release.cmake)
 #______________________________________________________________________________
 #                                                                  Dependencies
 include(cmake/add_dependency.cmake)
-add_dependency(ChimeraTK-ApplicationCore 02.02 REQUIRED)
+add_dependency(ChimeraTK-ApplicationCore 02.04 REQUIRED)
 
 IF(ENABLE_HDF5)
   FIND_PACKAGE(HDF5 REQUIRED COMPONENTS C CXX HL)

--- a/include/MicroDAQ.h
+++ b/include/MicroDAQ.h
@@ -60,6 +60,8 @@ namespace ChimeraTK {
         const std::unordered_set<std::string>& tags = {});
     MicroDAQ() {}
 
+    std::shared_ptr<BaseDAQ<TRIGGERTYPE>> getImplementation() { return impl; }
+
    protected:
 
     std::shared_ptr<BaseDAQ<TRIGGERTYPE>> impl;
@@ -203,8 +205,8 @@ namespace ChimeraTK {
   public:
 
     struct TriggerGroup : HierarchyModifyingGroup {
-      TriggerGroup(EntityOwner* owner, const std::string& pathToTrigger,
-                   const std::unordered_set<std::string>& tags = {})
+      TriggerGroup(
+          EntityOwner* owner, const std::string& pathToTrigger, const std::unordered_set<std::string>& tags = {})
       : HierarchyModifyingGroup(owner, HierarchyModifyingGroup::getPathName(pathToTrigger), "", tags),
         trigger{this, HierarchyModifyingGroup::getUnqualifiedName(pathToTrigger), "", "Trigger input"} {}
 

--- a/include/MicroDAQROOT.h
+++ b/include/MicroDAQROOT.h
@@ -45,8 +45,8 @@ namespace ChimeraTK {
       */
       RootDAQ(EntityOwner* owner, const std::string& name, const std::string& description,
              uint32_t decimationFactor = 10, uint32_t decimationThreshold = 1000, HierarchyModifier hierarchyModifier = HierarchyModifier::none,
-             const std::unordered_set<std::string>& tags = {}, const std::string &pathToTrigger="trigger")
-             : BaseDAQ<TRIGGERTYPE>(owner, name, description, ".root", decimationFactor, decimationThreshold, hierarchyModifier, tags, pathToTrigger) {
+             const std::unordered_set<std::string>& tags = {}, const std::string &pathToTrigger="trigger", const std::string &treeName="data")
+             : BaseDAQ<TRIGGERTYPE>(owner, name, description, ".root", decimationFactor, decimationThreshold, hierarchyModifier, tags, pathToTrigger), _treeName(treeName) {
         flushAfterNEntries.addTags(tags);
       }
 
@@ -64,6 +64,7 @@ namespace ChimeraTK {
      template<typename UserType>
      using BranchList = std::list<std::string>;
      TemplateUserTypeMap<BranchList>  _branchNameList;
+     std::string _treeName;
 
 
      friend struct detail::ROOTstorage<TRIGGERTYPE>;

--- a/src/MicroDAQ.cc
+++ b/src/MicroDAQ.cc
@@ -350,16 +350,14 @@ namespace ChimeraTK {
 
     struct MyVirtualModule : VirtualModule {
       using VirtualModule::VirtualModule;
-      using VirtualModule::findTagAndAppendToModule;
+      using VirtualModule::submodules;
     };
 
     MyVirtualModule temporary("temporary", "", ModuleType::ApplicationModule);
-    EntityOwner::findTagAndAppendToModule(temporary, "\\*\\*\\*MicroDAQ-internal\\*\\*\\*", false, false, true,
-                                          temporary);
-    // Eliminate all hierarchies, because otherwise we would introduce an extra level here. The MicroDAQ module has
-    // no internal sub-hierarchies, so this is ok.
-    temporary.findTagAndAppendToModule(virtualParent, tag, true, true, negate, root);
-
+    EntityOwner::findTagAndAppendToModule(temporary, R"(\*\*\*MicroDAQ-internal\*\*\*)", false, false, true, temporary);
+    for(auto& sm : temporary.submodules) {
+      sm.findTagAndAppendToModule(virtualParent, tag, false, false, negate, root);
+    }
   }
 
   INSTANTIATE_TEMPLATE_FOR_CHIMERATK_USER_TYPES(MicroDAQ);

--- a/src/MicroDAQHDF5.cc
+++ b/src/MicroDAQHDF5.cc
@@ -96,7 +96,7 @@ namespace ChimeraTK {
 
   template<typename TRIGGERTYPE>
   void HDF5DAQ<TRIGGERTYPE>::mainLoop() {
-    std::cout << "Initialising HDF5DAQ system...";
+    std::cout << "Initialising HDF5DAQ system..." << std::endl;
 
     // storage object
     detail::H5storage<TRIGGERTYPE> storage(this);
@@ -107,6 +107,9 @@ namespace ChimeraTK {
     // sort group list and make unique to make sure lower levels get created first
     storage.groupList.sort();
     storage.groupList.unique();
+
+    // write initial values
+    storage.processTrigger();
 
     // loop: process incoming triggers
     auto group = ApplicationModule::readAnyGroup();

--- a/src/MicroDAQROOT.cc
+++ b/src/MicroDAQROOT.cc
@@ -214,7 +214,7 @@ namespace ChimeraTK {
 
       if(outFile){
         if(!tree){
-          boost::fusion::for_each(treeDataMap.table, ROOTTreeCreator<TRIGGERTYPE>(*this, _owner->getName()));
+          boost::fusion::for_each(treeDataMap.table, ROOTTreeCreator<TRIGGERTYPE>(*this, _owner->_treeName));
           tree->Branch("timeStamp", &timeStamp);
         }
         // construct time stamp
@@ -266,6 +266,9 @@ namespace ChimeraTK {
     // sort group list and make unique to make sure lower levels get created first
     storage.groupList.sort();
     storage.groupList.unique();
+
+    // write initial values
+    storage.processTrigger();
 
     // loop: process incoming triggers
     auto group = ApplicationModule::readAnyGroup();

--- a/test/test_HDF5.C
+++ b/test/test_HDF5.C
@@ -169,14 +169,14 @@ struct testAppArray : public ChimeraTK::Application {
 BOOST_AUTO_TEST_CASE_TEMPLATE( test_scalar, T, test_types){
   testApp<T> app;
   ChimeraTK::TestFacility tf;
-  tf.setScalarDefault("nTriggersPerFile", (uint32_t)2);
-  tf.setScalarDefault("nMaxFiles", (uint32_t)5);
-  tf.setScalarDefault("enable", (int)1);
-  tf.setScalarDefault("directory", app.dir);
+  tf.setScalarDefault("/MicroDAQ/nTriggersPerFile", (uint32_t)2);
+  tf.setScalarDefault("/MicroDAQ/nMaxFiles", (uint32_t)5);
+  tf.setScalarDefault("/MicroDAQ/enable", (int)1);
+  tf.setScalarDefault("/MicroDAQ/directory", app.dir);
   tf.runApplication();
 
   for(size_t j = 0; j < 10; j++){
-    tf.writeScalar("Config/trigger",(int)j);
+    tf.writeScalar("/Config/trigger", (int)j);
     // sleep in order not to produce data sets with the same name!
     std::this_thread::sleep_for(std::chrono::milliseconds(5));
     tf.stepApplication();
@@ -219,14 +219,14 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( test_scalar, T, test_types){
 BOOST_AUTO_TEST_CASE_TEMPLATE( test_array, T, test_types){
   testAppArray<T> app;
   ChimeraTK::TestFacility tf;
-  tf.setScalarDefault("nTriggersPerFile", (uint32_t)2);
-  tf.setScalarDefault("nMaxFiles", (uint32_t)5);
-  tf.setScalarDefault("enable", (int)1);
-  tf.setScalarDefault("directory", app.dir);
+  tf.setScalarDefault("/MicroDAQ/nTriggersPerFile", (uint32_t)2);
+  tf.setScalarDefault("/MicroDAQ/nMaxFiles", (uint32_t)5);
+  tf.setScalarDefault("/MicroDAQ/enable", (int)1);
+  tf.setScalarDefault("/MicroDAQ/directory", app.dir);
   tf.runApplication();
 
   for(size_t j = 0; j < 10; j++){
-    tf.writeScalar("Config/trigger",(int)j);
+    tf.writeScalar("/Config/trigger", (int)j);
     // sleep in order not to produce data sets with the same name!
     std::this_thread::sleep_for(std::chrono::milliseconds(5));
     tf.stepApplication();

--- a/test/test_HDF5.C
+++ b/test/test_HDF5.C
@@ -37,6 +37,7 @@ using namespace boost::unit_test_framework;
 
 // list of user types the accessors are tested with
 typedef boost::mpl::list<int8_t, uint8_t, int16_t, uint16_t, int32_t, uint32_t, float, double> test_types;
+//typedef boost::mpl::list<int32_t> test_types;
 
 template <typename UserType>
 struct Dummy: public ChimeraTK::ApplicationModule{
@@ -67,29 +68,16 @@ struct testApp : public ChimeraTK::Application {
   }
   ~testApp() {shutdown();}
 
-  ChimeraTK::ControlSystemModule cs;
-
   Dummy<UserType> module{this,"Dummy","Dummy module"};
 
-  ChimeraTK::HDF5DAQ<UserType> daq{this,"MicroDAQ","Test of the MicroDAQ"};
+  ChimeraTK::HDF5DAQ<UserType> daq{this,"MicroDAQ","Test of the MicroDAQ", 10, 1000, ChimeraTK::HierarchyModifier::none, {} , "/Dummy/out"};
 
   std::string dir;
 
   void defineConnections() override {
-    ChimeraTK::VariableNetworkNode trigger = cs["Config"]("trigger");
-    trigger >> module.trigger;
-//    daq = ChimeraTK::HDF5DAQ<UserType>{this,"MicroDAQ","Test of the MicroDAQ"};
-    /**
-     * Don't use the trigger for the microDAQ module. If doing so it might happen,
-     * that the microDAQ module reads the latest value from the dummy module before it writes
-     * its new value. In that case the test will be interrupted as the new value written
-     * in the dummy module was not read by the microDAQ module.
-     * If using the out variable of the dummy module as trigger it is ensured
-     * that the latest value is read by the microDAQ module.
-     */
-    module.out >> daq.triggerGroup.trigger;
     daq.addSource(module.findTag("DAQ"),"DAQ");
-    daq.connectTo(cs);
+    ChimeraTK::ControlSystemModule cs;
+    findTag(".*").connectTo(cs);
 
     dumpConnections();
   }
@@ -100,16 +88,17 @@ template <typename UserType>
 struct DummyArray: public ChimeraTK::ApplicationModule{
   using ChimeraTK::ApplicationModule::ApplicationModule;
   ChimeraTK::ArrayOutput<UserType> out {this, "out", "", 10, "Dummy output", {"DAQ"}};
-  ChimeraTK::ScalarOutput<int> out1 {this, "outTrigger", "", "Dummy output", {"DAQ"}};
+  ChimeraTK::ScalarOutput<int> outTrigger {this, "outTrigger", "", "Dummy output", {"DAQ"}};
   ChimeraTK::ScalarPushInput<int> trigger {this, "trigger", "" ,"Trigger", {}};
 
   void mainLoop() override{
     out = {0,1,2,3,4,5,6,7,8,9};
     out.write();
-    out1.write();
+    outTrigger.write();
     while(true){
       trigger.read();
       std::transform(out.begin(), out.end(), out.begin(), [](UserType x){return x+1;});
+      outTrigger =  outTrigger + 1;
       writeAll();
     }
   }
@@ -132,31 +121,17 @@ struct testAppArray : public ChimeraTK::Application {
   const uint32_t _decimation;
   const uint32_t _decimationThreshold;
 
-  ChimeraTK::ControlSystemModule cs;
-
   DummyArray<UserType> module{this,"Dummy","Dummy module"};
 
   std::string dir;
 
-  ChimeraTK::HDF5DAQ<int> daq{this,"MicroDAQ","Test of the MicroDAQ", _decimation, _decimationThreshold};
+  ChimeraTK::HDF5DAQ<int> daq{this,"MicroDAQ","Test of the MicroDAQ", _decimation, _decimationThreshold, ChimeraTK::HierarchyModifier::none, {} , "/Dummy/outTrigger"};
 //  ChimeraTK::MicroDAQ<int> daq{this,"MicroDAQ","Test", 10, 1000};
 
   void defineConnections() override {
-    ChimeraTK::VariableNetworkNode trigger = cs["Config"]("trigger");
-    trigger >> module.trigger;
-    /**
-     * Don't use the trigger for the microDAQ module. If doing so it might happen,
-     * that the microDAQ module reads the latest value from the dummy module before it writes
-     * its new value. In that case the test will be interrupted as the new value written
-     * in the dummy module was not read by the microDAQ module.
-     * If using the out variable of the dummy module as trigger it is ensured
-     * that the latest value is read by the microDAQ module.
-     */
-    module.out1 >> daq.triggerGroup.trigger;
     daq.addSource(module.findTag("DAQ"),"DAQ");
-    daq.connectTo(cs);
-
-
+    ChimeraTK::ControlSystemModule cs;
+    findTag(".*").connectTo(cs);
     dumpConnections();
   }
 
@@ -175,8 +150,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( test_scalar, T, test_types){
   tf.setScalarDefault("/MicroDAQ/directory", app.dir);
   tf.runApplication();
 
-  for(size_t j = 0; j < 10; j++){
-    tf.writeScalar("/Config/trigger", (int)j);
+  for(size_t j = 0; j < 9; j++){
+    tf.writeScalar("/Dummy/trigger", (int)j);
     // sleep in order not to produce data sets with the same name!
     std::this_thread::sleep_for(std::chrono::milliseconds(5));
     tf.stepApplication();
@@ -188,7 +163,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( test_scalar, T, test_types){
   if (boost::filesystem::exists(daqPath)){
     if (boost::filesystem::is_directory(daqPath)){
       for(auto i = boost::filesystem::directory_iterator(daqPath); i != boost::filesystem::directory_iterator(); i++){
-        // look for file *buffer0001.h5 -> that file includes data out=2 and out=3
+        // look for file *buffer0001.h5 -> that file includes data out=3 and out=4
         std::string match = (boost::format("buffer%04d%s") % 1 % ".h5").str();
         if(boost::filesystem::canonical(i->path()).string().find(match) != std::string::npos){
           file = i->path();
@@ -225,8 +200,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( test_array, T, test_types){
   tf.setScalarDefault("/MicroDAQ/directory", app.dir);
   tf.runApplication();
 
-  for(size_t j = 0; j < 10; j++){
-    tf.writeScalar("/Config/trigger", (int)j);
+  for(size_t j = 0; j < 9; j++){
+    tf.writeScalar("/Dummy/trigger", (int)j);
     // sleep in order not to produce data sets with the same name!
     std::this_thread::sleep_for(std::chrono::milliseconds(5));
     tf.stepApplication();
@@ -260,10 +235,8 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( test_array, T, test_types){
   std::vector<float> v(10);
   dataset.read( &v[0], PredType::NATIVE_FLOAT, mspace1, filespace );
 
-  std::vector<float> v_test{3,4,5,6,7,8,9,10,11,12};
-  for(size_t i = 0; i < 10; i++){
-    BOOST_CHECK_EQUAL(v.at(i),v_test.at(i));
-  }
+  std::vector<float> v_test{2,3,4,5,6,7,8,9,10,11};
+  BOOST_CHECK_EQUAL_COLLECTIONS(v.begin(), v.end(), v_test.begin(), v_test.end());
 
   // remove currentBuffer and data0000.root to data0004.root and the directory uDAQ
   BOOST_CHECK_EQUAL(boost::filesystem::remove_all(app.dir), 7);


### PR DESCRIPTION
The trigger PV was connected wrongly at least if moved to an absolute position. Apparently, also
the other variables were already in the wrong place for a longer time, hence the correction of
the test.