### PR TITLE
fixes for ApplicationCore 3.0 (breaks API!)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,9 +10,9 @@ option(BUILD_TESTS "Build tests" ON)
 
 #______________________________________________________________________________
 #                                                                       VERSION
-set(${PROJECT_NAME}_MAJOR_VERSION 02)
+set(${PROJECT_NAME}_MAJOR_VERSION 03)
 set(${PROJECT_NAME}_MINOR_VERSION 00)
-set(${PROJECT_NAME}_PATCH_VERSION 01)
+set(${PROJECT_NAME}_PATCH_VERSION 00)
 include(${CMAKE_SOURCE_DIR}/cmake/set_version_numbers.cmake)
 
 include(${CMAKE_SOURCE_DIR}/cmake/set_default_flags.cmake)
@@ -22,7 +22,8 @@ include(${CMAKE_SOURCE_DIR}/cmake/set_default_build_to_release.cmake)
 #______________________________________________________________________________
 #                                                                  Dependencies
 include(cmake/add_dependency.cmake)
-add_dependency(ChimeraTK-ApplicationCore 02.09 REQUIRED)
+add_dependency(ChimeraTK-ApplicationCore 03.00 REQUIRED)
+add_dependency(Boost COMPONENTS date_time REQUIRED)
 
 IF(ENABLE_HDF5)
   FIND_PACKAGE(HDF5 REQUIRED COMPONENTS C CXX HL)
@@ -89,17 +90,18 @@ IF(ENABLE_ROOT)
         PRIVATE ${HDF5_HL_LIBRARIES}
                 ${HDF5_CXX_LIBRARIES}
                 ROOT::Tree
+                ${Boost_LIBRARIES}
     )
 ELSE()
     target_link_libraries(${PROJECT_NAME}
         PUBLIC ${ChimeraTK-ApplicationCore_LIBRARIES}
         PRIVATE ${HDF5_HL_LIBRARIES}
                 ${HDF5_CXX_LIBRARIES}
+                ${Boost_LIBRARIES}
     )
 ENDIF()
   
-
-find_package(Boost COMPONENTS unit_test_framework)                            
+find_package(Boost COMPONENTS unit_test_framework)
 if(Boost_UNIT_TEST_FRAMEWORK_FOUND AND BUILD_TESTS)
   enable_testing()
   FILE(COPY ${CMAKE_SOURCE_DIR}/test/dummy.dmap

--- a/include/MicroDAQ.h
+++ b/include/MicroDAQ.h
@@ -5,8 +5,7 @@
  *      Author: Klaus Zenker (HZDR)
  */
 
-#ifndef INCLUDE_MICRODAQ_H_
-#define INCLUDE_MICRODAQ_H_
+#pragma once
 
 #include <ChimeraTK/ApplicationCore/ApplicationModule.h>
 #include <ChimeraTK/ApplicationCore/ScalarAccessor.h>
@@ -32,6 +31,8 @@ namespace ChimeraTK {
   template<typename TRIGGERTYPE>
   class BaseDAQ;
 
+  /********************************************************************************************************************/
+
   /**
    *  Envelope class providing an easy-to-use high-level application interface. Instantiate this class in your
    *  application to use the MicroDAQ. It will configure itself using the ConfigReader (needs to be instantiated
@@ -48,30 +49,33 @@ namespace ChimeraTK {
      *  In the config file, the following variables are required:
      *  - Configuration/MicroDAQ/enable (int32): boolean flag whether the MicroDAQ system is enabled or not
      *  - Configuration/MicroDAQ/outputFormat (string): format of the output data, either "hdf5" or "root"
-     *  - Configuration/MicroDAQ/decimationFactor (uint32): decimation factor applied to large arrays (above decimationThreshold)
-     *  - Configuration/MicroDAQ/decimationThreshold (uint32): array size threshold above which the decimationFactor is applied
+     *  - Configuration/MicroDAQ/decimationFactor (uint32): decimation factor applied to large arrays (above
+     *    decimationThreshold)
+     *  - Configuration/MicroDAQ/decimationThreshold (uint32): array size threshold above which the decimationFactor is
+     *    applied
      *
      *  If Configuration/MicroDAQ/enable == 0, all other variables can be omitted.
      */
-    MicroDAQ(EntityOwner* owner, const std::string& name, const std::string& description, const std::string& inputTag,
-        const std::string& pathToTrigger, HierarchyModifier hierarchyModifier = HierarchyModifier::none,
-        const std::unordered_set<std::string>& tags = {});
-    MicroDAQ() {}
+    MicroDAQ(ModuleGroup* owner, const std::string& name, const std::string& description, const std::string& inputTag,
+        const std::string& pathToTrigger, const std::unordered_set<std::string>& tags = {});
+    MicroDAQ() = default;
 
     std::shared_ptr<BaseDAQ<TRIGGERTYPE>> getImplementation() { return impl; }
 
     /**
      * Add variable of a DeviceModule directly to the DAQ.
      * \param source The Device module to consider.
-     * \param namePrefix This prefix is used in the root file tree. It is prepended to the register names from the device.
+     * \param namePrefix This prefix is used in the root file tree. It is prepended to the register names from the
+     *        device.
      * \param submodule Use only a submodule of the device.
      */
-    void addDeviceModule(
-        const DeviceModule& source, const RegisterPath& namePrefix = "", const std::string& submodule = "");
+    void addDeviceModule(DeviceModule& source, const RegisterPath& namePrefix = "", const RegisterPath& submodule = "");
 
    protected:
     std::shared_ptr<BaseDAQ<TRIGGERTYPE>> impl;
   };
+
+  /********************************************************************************************************************/
 
   /**
    *  Base class used by the actual MicroDAQ implementations (HDF5, ROOT)
@@ -79,27 +83,76 @@ namespace ChimeraTK {
   template<typename TRIGGERTYPE>
   class BaseDAQ : public ApplicationModule {
    private:
-    std::unordered_set<std::string> _tags; ///< Tags to be added to all variables of the DAQ module.
+    // Required by public member initialisers, hence define first
+    // Tag name to tag control variables published by the MicroDAQ module itself, to exclude them from being added to
+    // the DAQ as a source.
+    const std::string _tagExcludeInternals{"_ChimeraTK_BaseDAQ_controlVars"};
+
+   public:
+    BaseDAQ(ModuleGroup* owner, const std::string& name, const std::string& description, const std::string& suffix,
+        uint32_t decimationFactor = 10, uint32_t decimationThreshold = 1000,
+        const std::unordered_set<std::string>& tags = {}, const std::string& pathToTrigger = "trigger")
+    : ApplicationModule(owner, name, description, tags), _decimationFactor(decimationFactor),
+      _decimationThreshold(decimationThreshold), _daqDefaultPath((boost::filesystem::current_path() / "uDAQ").string()),
+      _suffix(suffix), trigger(this, pathToTrigger, "", "", {_tagExcludeInternals}) {}
+
+    BaseDAQ() : _decimationFactor(0), _decimationThreshold(0) {}
 
     /**
-     * Delete file corresponding to currentBuffer from the ringbuffer.
-     */
-    void deleteRingBufferFile();
-
-    /**
-     * Check if ringbuffer file corresponding to currentBuffer exists.
+     * Check if accessor uses the DAQ trigger as external trigger.
      *
-     * Since timestamps are prefixed to the buffer files here we check
-     * the last part of the file.
-     *
-     * \return True if file with currentBuffer number exists.
+     * In that case it has to be updated as well as the trigger before reading data by the DAQ.
      */
-    bool checkFile();
+    template<typename UserType>
+    bool isAccessorUsingDAQTrigger(const ArrayPushInput<UserType>& accessor);
+
+    ScalarPushInput<TRIGGERTYPE> trigger;
+
+    ScalarPollInput<std::string> setPath{this, "directory",
+        "", "Directory where to store the DAQ data. If not set a subdirectory called uDAQ in the current directory is used.",
+        {_tagExcludeInternals}};
+
+    ScalarPollInput<ChimeraTK::Boolean> enable{this, "activate", "", "Activate the DAQ.", {_tagExcludeInternals}};
+
+    ScalarPollInput<uint32_t> nMaxFiles{this, "nMaxFiles", "",
+        "Maximum number of files in the ring buffer "
+        "(oldest file will be overwritten).",
+        {_tagExcludeInternals}};
+
+    ScalarPollInput<uint32_t> nTriggersPerFile{
+        this, "nTriggersPerFile", "", "Number of triggers stored in each file.", {_tagExcludeInternals}};
+
+    ScalarOutput<std::string> currentPath{this, "currentDirectory", "",
+        "Directory currently used for DAQ. To switch directories turn off DAQ and set new directory.",
+        {_tagExcludeInternals}};
+
+    ScalarOutput<uint32_t> currentBuffer{this, "currentBuffer", "",
+        "File number currently written to. If DAQ this shows the next buffer to be used by the DAQ.",
+        {_tagExcludeInternals}};
+
+    ScalarOutput<uint32_t> currentEntry{
+        this, "currentEntry", "", "Last entry number written. Is reset with every new file.", {_tagExcludeInternals}};
+
+    ScalarOutput<ChimeraTK::Boolean> errorStatus{
+        this, "DAQError", "", "True in case an error occurred. Reset by toggling enable.", {_tagExcludeInternals}};
 
     /**
-     * Interal function that knows if the source is a ControlsystemModul
+     * Add all PVs found below the given directory.
+     *
+     * @param qualifiedDirectoryPath qualified name of the directory
+     * @param inputTag name of the tag to select. If empty, use all PVs.
      */
-    virtual void addSource(const Module& source, const RegisterPath& namePrefix, const bool& isCSModule);
+    void addSource(const std::string& qualifiedDirectoryPath, const std::string& inputTag);
+
+    void mainLoop() override = 0;
+
+    friend struct detail::BaseDAQAccessorAttacher<TRIGGERTYPE>;
+
+    /**
+     * Visitor function for use with the ApplicationCore Model to add PVs as DAQ sources
+     */
+    void addVariableFromModel(const ChimeraTK::Model::ProcessVariableProxy& pv, const RegisterPath& namePrefix = "",
+        const RegisterPath& submodule = "");
 
    protected:
     /** Parameters for the data decimation */
@@ -113,31 +166,25 @@ namespace ChimeraTK {
 
     std::string _prefix; ///< Current prefix path+date
 
-    /** Map of VariableGroups required to build the hierarchies. The key it the
-     * full path name. */
-    std::map<std::string, VariableGroup> _groupMap;
+    /** Overall variable name list, used to detect name collisions */
+    std::set<std::string> _overallVariableList;
 
-    /** boost::fusion::map of UserTypes to std::lists containing the names of the
-     * accessors. Technically there would be no need to use TemplateUserTypeMap
-     * for this (as type does not depend on the UserType), but since these lists
-     * must be filled consistently with the accessorListMap, the same construction
-     * is used here. */
+    /**
+     * boost::fusion::map of UserTypes to std::lists containing the names of the accessors. Technically there would be
+     * no need to use TemplateUserTypeMap for this (as type does not depend on the UserType), but since these lists must
+     * be filled consistently with the accessorListMap, the same construction is used here.
+     */
     template<typename UserType>
     using NameList = std::list<std::string>;
     TemplateUserTypeMapNoVoid<NameList> _nameListMap;
 
-    /** Overall variable name list, used to detect name collisions */
-    std::list<std::string> _overallVariableList;
-
-    /** boost::fusion::map of UserTypes to std::lists containing the
-     * ArrayPushInput accessors. These accessors are dynamically created by the
-     * AccessorAttacher. */
+    /**
+     * boost::fusion::map of UserTypes to std::lists containing the ArrayPushInput accessors. These accessors are
+     * dynamically created by the AccessorAttacher.
+     */
     template<typename UserType>
     using AccessorList = std::list<ArrayPushInput<UserType>>;
     TemplateUserTypeMapNoVoid<AccessorList> _accessorListMap;
-
-    template<typename UserType>
-    VariableNetworkNode getAccessor(const std::string& variableName);
 
     /**
      * Set the daq path.
@@ -180,85 +227,79 @@ namespace ChimeraTK {
      */
     void disableDAQ();
 
-   public:
-    BaseDAQ(EntityOwner* owner, const std::string& name, const std::string& description, const std::string& suffix,
-        uint32_t decimationFactor = 10, uint32_t decimationThreshold = 1000,
-        HierarchyModifier hierarchyModifier = HierarchyModifier::none, const std::unordered_set<std::string>& tags = {},
-        const std::string& pathToTrigger = "trigger")
-    : ApplicationModule(owner, name, description, hierarchyModifier), _tags(tags), _decimationFactor(decimationFactor),
-      _decimationThreshold(decimationThreshold), _daqDefaultPath((boost::filesystem::current_path() / "uDAQ").string()),
-      _suffix(suffix), triggerGroup(this, pathToTrigger[0] != '/' ? "./" + pathToTrigger : pathToTrigger, tags) {}
-
-    BaseDAQ() : _decimationFactor(0), _decimationThreshold(0) {}
-
-    void findTagAndAppendToModule(VirtualModule& virtualParent, const std::string& tag, bool eliminateAllHierarchies,
-        bool eliminateFirstHierarchy, bool negate, VirtualModule& root) const override;
+   private:
+    /**
+     * Delete file corresponding to currentBuffer from the ringbuffer.
+     */
+    void deleteRingBufferFile();
 
     /**
-     * Check if accessor uses the DAQ trigger as external trigger.
+     * Check if ringbuffer file corresponding to currentBuffer exists.
      *
-     * In that case it has to be updated as well as the trigger before reading
-     * data by the DAQ.
+     * Since timestamps are prefixed to the buffer files here we check
+     * the last part of the file.
+     *
+     * \return True if file with currentBuffer number exists.
      */
-    template<typename UserType>
-    bool isAccessorUsingDAQTrigger(const ArrayPushInput<UserType>& accessor) {
-      // Find out if accessor has external trigger and if it is the DAQ trigger
-      auto network = &((VariableNetworkNode)accessor).getOwner();
-      auto triggerNode = &(triggerGroup.trigger);
-      // check if network has external trigger
-      if(network->getTriggerType() == VariableNetwork::TriggerType::external) {
-        // check if external trigger is the DAQ trigger
-        if(network->getFeedingNode().getExternalTrigger() == (VariableNetworkNode)*triggerNode) {
-          return true;
-        }
-      }
-      return false;
+    bool checkFile();
+  };
+
+  /********************************************************************************************************************/
+
+  DECLARE_TEMPLATE_FOR_CHIMERATK_USER_TYPES_NO_VOID(BaseDAQ);
+
+  /********************************************************************************************************************/
+  /********************************************************************************************************************/
+
+  template<typename TRIGGERTYPE>
+  template<typename UserType>
+  bool BaseDAQ<TRIGGERTYPE>::isAccessorUsingDAQTrigger(const ArrayPushInput<UserType>& accessor) {
+    // Obtain the path of the trigger for the given accessor (stays empty if no trigger)
+    std::string triggerPath;
+    auto visitor = [&](const Model::DeviceModuleProxy& dev) { triggerPath = dev.getTrigger().getFullyQualifiedPath(); };
+    accessor.getModel().visit(visitor, Model::keepDeviceModules, Model::adjacentInSearch, Model::keepPvAccess);
+
+    // compare to the path of the DAQ trigger
+    return triggerPath == trigger.getModel().getFullyQualifiedPath();
+  }
+
+  /********************************************************************************************************************/
+
+  template<typename TRIGGERTYPE>
+  void BaseDAQ<TRIGGERTYPE>::addVariableFromModel(
+      const ChimeraTK::Model::ProcessVariableProxy& pv, const RegisterPath& namePrefix, const RegisterPath& submodule) {
+    // do not add control variables published by the MicroDAQ module itself
+    if(pv.getTags().count(_tagExcludeInternals) > 0) {
+      return;
     }
 
-    struct TriggerGroup : HierarchyModifyingGroup {
-      TriggerGroup(
-          EntityOwner* owner, const std::string& pathToTrigger, const std::unordered_set<std::string>& tags = {})
-      : HierarchyModifyingGroup(owner, HierarchyModifyingGroup::getPathName(pathToTrigger), "", tags),
-        trigger{this, HierarchyModifyingGroup::getUnqualifiedName(pathToTrigger), "", "Trigger input"} {}
+    // gather information about the PV
+    auto name = pv.getFullyQualifiedPath();
+    const auto& type = pv.getNodes().front().getValueType(); // All node types must be equal for a PV
+    auto length = pv.getNodes().front().getNumberOfElements();
 
-      TriggerGroup() {}
+    // check if qualified path name patches the given submodule name
+    if(submodule != "/" && !boost::starts_with(name, std::string(submodule) + "/")) {
+      return;
+    }
 
-      ScalarPushInput<TRIGGERTYPE> trigger;
-    } triggerGroup;
+    // generate name as visible in the DAQ
+    std::string daqName = namePrefix / name.substr(submodule.length());
 
-    ScalarPollInput<std::string> setPath{this, "directory",
-        "", "Directory where to store the DAQ data. If not set a subdirectory called uDAQ in the current directory is used.",
-        _tags};
+    // check for name collision
+    if(_overallVariableList.count(daqName) > 0) {
+      throw ChimeraTK::logic_error("MicroDAQ: DAQ name '" + daqName + "' already taken when adding PV '" + name + "'.");
+    }
+    _overallVariableList.insert(daqName);
 
-    ScalarPollInput<ChimeraTK::Boolean> enable{this, "activate", "", "Activate the DAQ.", _tags};
+    // create accessor and fill lists
+    callForTypeNoVoid(type, [&](auto t) {
+      using UserType = decltype(t);
+      boost::fusion::at_key<UserType>(_nameListMap.table).push_back(daqName);
+      boost::fusion::at_key<UserType>(_accessorListMap.table).emplace_back(this, name, "", length, "");
+    });
+  }
 
-    ScalarPollInput<uint32_t> nMaxFiles{this, "nMaxFiles", "",
-        "Maximum number of files in the ring buffer "
-        "(oldest file will be overwritten).",
-        _tags};
+  /********************************************************************************************************************/
 
-    ScalarPollInput<uint32_t> nTriggersPerFile{
-        this, "nTriggersPerFile", "", "Number of triggers stored in each file.", _tags};
-
-    ScalarOutput<std::string> currentPath{this, "currentDirectory", "",
-        "Directory currently used for DAQ. To switch directories turn off DAQ and set new directory.", _tags};
-
-    ScalarOutput<uint32_t> currentBuffer{this, "currentBuffer", "",
-        "File number currently written to. If DAQ this shows the next buffer to be used by the DAQ.", _tags};
-
-    ScalarOutput<uint32_t> currentEntry{
-        this, "currentEntry", "", "Last entry number written. Is reset with every new file.", _tags};
-
-    ScalarOutput<ChimeraTK::Boolean> errorStatus{
-        this, "DAQError", "", "True in case an error occurred. Reset by toggling enable.", _tags};
-
-    virtual void addSource(const Module& source, const RegisterPath& namePrefix = "");
-
-    virtual void mainLoop() override = 0;
-
-    friend struct detail::BaseDAQAccessorAttacher<TRIGGERTYPE>;
-  };
-  DECLARE_TEMPLATE_FOR_CHIMERATK_USER_TYPES_NO_VOID(BaseDAQ);
 } // namespace ChimeraTK
-
-#endif /* INCLUDE_MICRODAQ_H_ */

--- a/include/MicroDAQ.h
+++ b/include/MicroDAQ.h
@@ -23,10 +23,6 @@
 #include <string>
 
 namespace ChimeraTK {
-  namespace detail {
-    template<typename TRIGGERTYPE>
-    struct BaseDAQAccessorAttacher;
-  } // namespace detail
 
   template<typename TRIGGERTYPE>
   class BaseDAQ;
@@ -145,8 +141,6 @@ namespace ChimeraTK {
     void addSource(const std::string& qualifiedDirectoryPath, const std::string& inputTag);
 
     void mainLoop() override = 0;
-
-    friend struct detail::BaseDAQAccessorAttacher<TRIGGERTYPE>;
 
     /**
      * Visitor function for use with the ApplicationCore Model to add PVs as DAQ sources

--- a/include/MicroDAQ.h
+++ b/include/MicroDAQ.h
@@ -8,18 +8,18 @@
 #pragma once
 
 #include <ChimeraTK/ApplicationCore/ApplicationModule.h>
-#include <ChimeraTK/ApplicationCore/ScalarAccessor.h>
 #include <ChimeraTK/ApplicationCore/ArrayAccessor.h>
-#include <ChimeraTK/ApplicationCore/VariableGroup.h>
-#include <ChimeraTK/ApplicationCore/ModuleGroup.h>
 #include <ChimeraTK/ApplicationCore/ConfigReader.h>
 #include <ChimeraTK/ApplicationCore/HierarchyModifyingGroup.h>
+#include <ChimeraTK/ApplicationCore/ModuleGroup.h>
+#include <ChimeraTK/ApplicationCore/ScalarAccessor.h>
+#include <ChimeraTK/ApplicationCore/VariableGroup.h>
 
 #include <boost/filesystem.hpp>
 
-#include <map>
 #include <algorithm>
 #include <cctype>
+#include <map>
 #include <string>
 
 namespace ChimeraTK {
@@ -92,9 +92,9 @@ namespace ChimeraTK {
     BaseDAQ(ModuleGroup* owner, const std::string& name, const std::string& description, const std::string& suffix,
         uint32_t decimationFactor = 10, uint32_t decimationThreshold = 1000,
         const std::unordered_set<std::string>& tags = {}, const std::string& pathToTrigger = "trigger")
-    : ApplicationModule(owner, name, description, tags), _decimationFactor(decimationFactor),
-      _decimationThreshold(decimationThreshold), _daqDefaultPath((boost::filesystem::current_path() / "uDAQ").string()),
-      _suffix(suffix), trigger(this, pathToTrigger, "", "", {_tagExcludeInternals}) {}
+    : ApplicationModule(owner, name, description, tags), trigger(this, pathToTrigger, "", "", {_tagExcludeInternals}),
+      _decimationFactor(decimationFactor), _decimationThreshold(decimationThreshold),
+      _daqDefaultPath((boost::filesystem::current_path() / "uDAQ").string()), _suffix(suffix) {}
 
     BaseDAQ() : _decimationFactor(0), _decimationThreshold(0) {}
 

--- a/include/MicroDAQ.h
+++ b/include/MicroDAQ.h
@@ -142,6 +142,8 @@ namespace ChimeraTK {
 
     void mainLoop() override = 0;
 
+    void prepare() override;
+
     /**
      * Visitor function for use with the ApplicationCore Model to add PVs as DAQ sources
      */

--- a/include/MicroDAQHDF5.h
+++ b/include/MicroDAQHDF5.h
@@ -5,8 +5,7 @@
  *      Author: Klaus Zenker (HZDR)
  */
 
-#ifndef INCLUDE_MICRODAQHDF5_H_
-#define INCLUDE_MICRODAQHDF5_H_
+#pragma once
 
 #include <ChimeraTK/SupportedUserTypes.h>
 #include <ChimeraTK/ApplicationCore/ArrayAccessor.h>
@@ -25,6 +24,8 @@ namespace ChimeraTK {
     struct H5DataWriter;
   } // namespace detail
 
+  /********************************************************************************************************************/
+
   /**
    *  MicroDAQ module for logging data to HDF5 files. This can be usefull in
    * enviromenents where no sufficient logging of data is possible through the
@@ -40,20 +41,16 @@ namespace ChimeraTK {
      * size bigger than decimationThreshold will be decimated by decimationFactor
      * before writing to the HDF5 file.
      */
-    HDF5DAQ(EntityOwner* owner, const std::string& name, const std::string& description, uint32_t decimationFactor = 10,
-        uint32_t decimationThreshold = 1000, HierarchyModifier hierarchyModifier = HierarchyModifier::none,
-        const std::unordered_set<std::string>& tags = {}, const std::string& pathToTrigger = "trigger")
-    : BaseDAQ<TRIGGERTYPE>(owner, name, description, ".h5", decimationFactor, decimationThreshold, hierarchyModifier,
-          tags, pathToTrigger) {}
+    HDF5DAQ(ModuleGroup* owner, const std::string& name, const std::string& description, uint32_t decimationFactor = 10,
+        uint32_t decimationThreshold = 1000, const std::unordered_set<std::string>& tags = {},
+        const std::string& pathToTrigger = "trigger")
+    : BaseDAQ<TRIGGERTYPE>(
+          owner, name, description, ".h5", decimationFactor, decimationThreshold, tags, pathToTrigger) {}
 
     /** Default constructor, creates a non-working module. Can be used for late
      * initialisation. */
     HDF5DAQ() : BaseDAQ<TRIGGERTYPE>() {}
 
-    /**
-     * Overload that calls virtualiseFromCatalog.
-     */
-    //    void addSource(const DeviceModule& source, const RegisterPath& namePrefix = "");
    protected:
     void mainLoop() override;
 
@@ -62,8 +59,10 @@ namespace ChimeraTK {
     friend struct detail::H5DataWriter<TRIGGERTYPE>;
   };
 
+  /********************************************************************************************************************/
+
   DECLARE_TEMPLATE_FOR_CHIMERATK_USER_TYPES_NO_VOID(HDF5DAQ);
 
-} // namespace ChimeraTK
+  /********************************************************************************************************************/
 
-#endif /* INCLUDE_MICRODAQHDF5_H_ */
+} // namespace ChimeraTK

--- a/include/MicroDAQROOT.h
+++ b/include/MicroDAQROOT.h
@@ -5,14 +5,13 @@
  *      Author: Klaus Zenker (HZDR)
  */
 
-#ifndef INCLUDE_MICRODAQROOT_H_
-#define INCLUDE_MICRODAQROOT_H_
-
-#include <ChimeraTK/SupportedUserTypes.h>
-#include <ChimeraTK/ApplicationCore/ArrayAccessor.h>
-#include <ChimeraTK/ApplicationCore/VariableGroup.h>
+#pragma once
 
 #include "MicroDAQ.h"
+
+#include <ChimeraTK/ApplicationCore/ArrayAccessor.h>
+#include <ChimeraTK/ApplicationCore/VariableGroup.h>
+#include <ChimeraTK/SupportedUserTypes.h>
 
 namespace ChimeraTK {
 
@@ -27,6 +26,9 @@ namespace ChimeraTK {
     struct ROOTDataWriter;
 
   } // namespace detail
+
+  /********************************************************************************************************************/
+
   /**
    *  MicroDAQ module for logging data to ROOT files. This can be useful in
    * environments where no sufficient logging of data is possible through the
@@ -42,12 +44,11 @@ namespace ChimeraTK {
       * size bigger than decimationThreshold will be decimated by decimationFactor
       * before writing to the ROOT file.
       */
-    RootDAQ(EntityOwner* owner, const std::string& name, const std::string& description, uint32_t decimationFactor = 10,
-        uint32_t decimationThreshold = 1000, HierarchyModifier hierarchyModifier = HierarchyModifier::none,
-        const std::unordered_set<std::string>& tags = {}, const std::string& pathToTrigger = "trigger",
-        const std::string& treeName = "data")
-    : BaseDAQ<TRIGGERTYPE>(owner, name, description, ".root", decimationFactor, decimationThreshold, hierarchyModifier,
-          tags, pathToTrigger),
+    RootDAQ(ModuleGroup* owner, const std::string& name, const std::string& description, uint32_t decimationFactor = 10,
+        uint32_t decimationThreshold = 1000, const std::unordered_set<std::string>& tags = {},
+        const std::string& pathToTrigger = "trigger", const std::string& treeName = "data")
+    : BaseDAQ<TRIGGERTYPE>(
+          owner, name, description, ".root", decimationFactor, decimationThreshold, tags, pathToTrigger),
       _treeName(treeName) {
       flushAfterNEntries.addTags(tags);
     }
@@ -73,7 +74,11 @@ namespace ChimeraTK {
     friend struct detail::ROOTTreeCreator<TRIGGERTYPE>;
     friend struct detail::ROOTDataWriter<TRIGGERTYPE>;
   };
-  DECLARE_TEMPLATE_FOR_CHIMERATK_USER_TYPES_NO_VOID(RootDAQ);
-} // namespace ChimeraTK
 
-#endif /* INCLUDE_MICRODAQROOT_H_ */
+  /********************************************************************************************************************/
+
+  DECLARE_TEMPLATE_FOR_CHIMERATK_USER_TYPES_NO_VOID(RootDAQ);
+
+  /********************************************************************************************************************/
+
+} // namespace ChimeraTK

--- a/src/MicroDAQ.cc
+++ b/src/MicroDAQ.cc
@@ -283,4 +283,14 @@ namespace ChimeraTK {
 
   /********************************************************************************************************************/
 
+  template<typename TRIGGERTYPE>
+  void BaseDAQ<TRIGGERTYPE>::prepare() {
+    if(!_overallVariableList.size()) {
+      throw logic_error(
+          "No variables are connected to the MicroDAQ module. Did you use the correct tag or connect a Device?");
+    }
+  }
+
+  /********************************************************************************************************************/
+
 } // namespace ChimeraTK

--- a/src/MicroDAQ.cc
+++ b/src/MicroDAQ.cc
@@ -7,16 +7,15 @@
 
 #include "MicroDAQ.h"
 
+#include <ChimeraTK/ApplicationCore/DeviceModule.h>
+
+#include <boost/algorithm/string.hpp>
+#include <boost/date_time/posix_time/posix_time.hpp>
+#include <boost/format.hpp>
+
 #include <fstream>
 #include <iostream>
 #include <string.h>
-
-#include <boost/format.hpp>
-#include "boost/date_time/posix_time/posix_time.hpp"
-#include <boost/algorithm/string.hpp>
-
-#include <ChimeraTK/ApplicationCore/ControlSystemModule.h>
-#include <ChimeraTK/ApplicationCore/DeviceModule.h>
 
 #ifdef ENABLE_HDF5
 #  include "MicroDAQHDF5.h"
@@ -27,11 +26,12 @@
 
 namespace ChimeraTK {
 
+  /********************************************************************************************************************/
+
   template<typename TRIGGERTYPE>
-  MicroDAQ<TRIGGERTYPE>::MicroDAQ(EntityOwner* owner, const std::string& name, const std::string& description,
-      const std::string& inputTag, const std::string& pathToTrigger, HierarchyModifier hierarchyModifier,
-      const std::unordered_set<std::string>& tags)
-  : ModuleGroup(owner, name, "", HierarchyModifier::hideThis) {
+  MicroDAQ<TRIGGERTYPE>::MicroDAQ(ModuleGroup* owner, const std::string& name, const std::string& description,
+      const std::string& inputTag, const std::string& pathToTrigger, const std::unordered_set<std::string>& tags)
+  : ModuleGroup(owner, ".", "") {
     // do nothing if the entire module is disabled
     if(appConfig().template get<Boolean>("Configuration/MicroDAQ/enable") == false) return;
 
@@ -47,7 +47,7 @@ namespace ChimeraTK {
     if(type == "hdf5") {
 #ifdef ENABLE_HDF5
       impl = std::make_shared<HDF5DAQ<TRIGGERTYPE>>(
-          this, name, description, decimationFactor, decimationThreshold, hierarchyModifier, tags, pathToTrigger);
+          this, name, description, decimationFactor, decimationThreshold, tags, pathToTrigger);
 #else
       throw ChimeraTK::logic_error("MicroDAQ: Output format HDF5 selected but not compiled in.");
 #endif
@@ -55,7 +55,7 @@ namespace ChimeraTK {
     else if(type == "root") {
 #ifdef ENABLE_ROOT
       impl = std::make_shared<RootDAQ<TRIGGERTYPE>>(
-          this, name, description, decimationFactor, decimationThreshold, hierarchyModifier, tags, pathToTrigger);
+          this, name, description, decimationFactor, decimationThreshold, tags, pathToTrigger);
 #else
       throw ChimeraTK::logic_error("MicroDAQ: Output format ROOT selected but not compiled in.");
 #endif
@@ -65,134 +65,45 @@ namespace ChimeraTK {
     }
 
     // connect input data with the DAQ implementation
-    impl->addSource(owner->findTag(inputTag));
+    impl->addSource(".", inputTag);
   }
+
+  /********************************************************************************************************************/
 
   template<typename TRIGGERTYPE>
   void MicroDAQ<TRIGGERTYPE>::addDeviceModule(
-      const DeviceModule& source, const RegisterPath& namePrefix, const std::string& submodule) {
+      DeviceModule& source, const RegisterPath& namePrefix, const RegisterPath& submodule) {
     if(impl) {
-      auto mod = source.virtualiseFromCatalog();
-      if(submodule.empty()) {
-        impl->addSource(mod, namePrefix);
+      source.getModel().visit([&](auto pv) { impl->addVariableFromModel(pv, namePrefix, submodule); },
+          Model::keepPvAccess, Model::adjacentSearch, Model::keepProcessVariables);
+    }
+  }
+
+  /********************************************************************************************************************/
+
+  template<typename TRIGGERTYPE>
+  void BaseDAQ<TRIGGERTYPE>::addSource(const std::string& qualifiedDirectoryPath, const std::string& inputTag) {
+    auto model = dynamic_cast<ModuleGroup*>(_owner)->getModel();
+    auto neighbourDir = model.visit(ChimeraTK::Model::returnDirectory, ChimeraTK::Model::getNeighbourDirectory,
+        ChimeraTK::Model::returnFirstHit(ChimeraTK::Model::DirectoryProxy{}));
+
+    auto found = neighbourDir.visitByPath(qualifiedDirectoryPath, [&](auto sourceDir) {
+      if(inputTag.empty()) {
+        sourceDir.visit([&](auto pv) { addVariableFromModel(pv); }, ChimeraTK::Model::breadthFirstSearch,
+            ChimeraTK::Model::keepProcessVariables);
       }
       else {
-        impl->addSource(mod.submodule(submodule), namePrefix);
+        sourceDir.visit([&](auto pv) { addVariableFromModel(pv); }, ChimeraTK::Model::breadthFirstSearch,
+            ChimeraTK::Model::keepProcessVariables && ChimeraTK::Model::keepTag(inputTag));
       }
+    });
+
+    if(!found) {
+      throw ChimeraTK::logic_error("Path passed to BaseDAQ<TRIGGERTYPE>::addSource() not found!");
     }
   }
 
-  namespace detail {
-
-    /** Callable class for use with  boost::fusion::for_each: Attach the given
-     * accessor to the DAQ with proper handling of the UserType. */
-    template<typename TRIGGERTYPE>
-    struct BaseDAQAccessorAttacher {
-      BaseDAQAccessorAttacher(VariableNetworkNode& feeder, BaseDAQ<TRIGGERTYPE>* owner, const std::string& name)
-      : _feeder(feeder), _owner(owner), _name(name) {}
-
-      template<typename PAIR>
-      void operator()(PAIR&) const {
-        // only continue if the call is for the right type
-        if(typeid(typename PAIR::first_type) != _feeder.getValueType()) return;
-
-        // check if variable name already registered
-        for(auto& name : _owner->_overallVariableList) {
-          if(name == _name) {
-            return;
-          }
-        }
-        _owner->_overallVariableList.push_back(_name);
-
-        // register connection
-        if(_feeder.getMode() == UpdateMode::poll && _feeder.getDirection().dir == VariableDirection::feeding)
-          _feeder[_owner->triggerGroup.trigger] >> _owner->template getAccessor<typename PAIR::first_type>(_name);
-        else
-          _feeder >> _owner->template getAccessor<typename PAIR::first_type>(_name);
-      }
-
-      VariableNetworkNode& _feeder;
-      BaseDAQ<TRIGGERTYPE>* _owner;
-      const std::string& _name;
-    };
-
-  } // namespace detail
-
-  template<typename TRIGGERTYPE>
-  template<typename UserType>
-  VariableNetworkNode BaseDAQ<TRIGGERTYPE>::getAccessor(const std::string& variableName) {
-    // add accessor and name to lists
-    auto& tmpAccessorList = boost::fusion::at_key<UserType>(_accessorListMap.table);
-    auto& nameList = boost::fusion::at_key<UserType>(_nameListMap.table);
-    auto dirName = variableName.substr(0, variableName.find_last_of("/"));
-    auto baseName = variableName.substr(variableName.find_last_of("/") + 1);
-    if(BaseDAQ<TRIGGERTYPE>::_groupMap.count(dirName) < 1) {
-      tmpAccessorList.emplace_back(this, baseName, "", 0, "");
-    }
-    else {
-      tmpAccessorList.emplace_back(&BaseDAQ<TRIGGERTYPE>::_groupMap[dirName], baseName, "", 0, "");
-    }
-    nameList.push_back(variableName);
-
-    // add internal tag so we can exclude these variables in findTagAndAppendToModule()
-    tmpAccessorList.back().addTag("***MicroDAQ-internal***");
-
-    // return the accessor
-    return tmpAccessorList.back();
-  }
-
-  template<typename TRIGGERTYPE>
-  void BaseDAQ<TRIGGERTYPE>::addSource(const Module& source, const RegisterPath& namePrefix, const bool& isCSModule) {
-    // for simplification, first create a VirtualModule containing the correct
-    // hierarchy structure (obeying eliminate hierarchy etc.)
-    auto dynamicModel = source.findTag(".*"); /// @todo use virtualise() instead
-
-    // create variable group map for namePrefix if needed
-    if(_groupMap.find(namePrefix) == _groupMap.end()) {
-      // search for existing parent (if any)
-      auto parentPrefix = namePrefix;
-      while(_groupMap.find(parentPrefix) == _groupMap.end()) {
-        if(parentPrefix == "/") break; // no existing parent found
-        parentPrefix = std::string(parentPrefix).substr(0, std::string(parentPrefix).find_last_of("/"));
-      }
-      // create all not-yet-existing parents
-      while(parentPrefix != namePrefix) {
-        EntityOwner* owner = this;
-        if(parentPrefix != "/") owner = &_groupMap[parentPrefix];
-        auto stop = std::string(namePrefix).find_first_of("/", parentPrefix.length() + 1);
-        if(stop == std::string::npos) stop = namePrefix.length();
-        RegisterPath name = std::string(namePrefix).substr(parentPrefix.length(), stop - parentPrefix.length());
-        parentPrefix /= name;
-        _groupMap[parentPrefix] = VariableGroup(owner, std::string(name).substr(1), "");
-      }
-    }
-
-    // add all accessors on this hierarchy level
-    for(auto& acc : dynamicModel.getAccessorList()) {
-      // seems like getName returns the full path for ControlSystemModule whereas it returns only the accessor name for ApplicationModule
-      // Btw getQualifiedName returns the full path for ApplicationModule and nothing for ControlsystemModule
-      std::string name = acc.getName();
-      // for modules with deleted hierarchy names might still include '/',
-      // e.g. Controller includes 'FeedForward/Table/I' and remove FeedForward/Table would lead to multiple
-      // I variables with namePrefix Controller -> only do the removal for CS modules
-      if(isCSModule && name.find("/") != std::string::npos) name = name.substr(name.find_last_of("/") + 1);
-      boost::fusion::for_each(
-          _accessorListMap.table, detail::BaseDAQAccessorAttacher<TRIGGERTYPE>(acc, this, namePrefix / name));
-    }
-
-    // recurse into submodules
-    for(auto mod : dynamicModel.getSubmoduleList()) {
-      addSource(*mod, namePrefix / mod->getName(), isCSModule);
-    }
-  }
-
-  template<typename TRIGGERTYPE>
-  void BaseDAQ<TRIGGERTYPE>::addSource(const Module& source, const RegisterPath& namePrefix) {
-    //\ToDo: Rework the variable name creation without CS specific workaround
-    bool isCSModule = false;
-    if(dynamic_cast<const ControlSystemModule*>(&source) != nullptr) isCSModule = true;
-    addSource(source, namePrefix, isCSModule);
-  }
+  /********************************************************************************************************************/
 
   template<typename TRIGGERTYPE>
   void BaseDAQ<TRIGGERTYPE>::setDAQPath() {
@@ -211,6 +122,9 @@ namespace ChimeraTK {
       std::cerr << "Failed setting new DAQ path." << std::endl;
     }
   }
+
+  /********************************************************************************************************************/
+
   template<typename TRIGGERTYPE>
   bool BaseDAQ<TRIGGERTYPE>::checkFile() {
     try {
@@ -233,6 +147,8 @@ namespace ChimeraTK {
     return false;
   }
 
+  /********************************************************************************************************************/
+
   template<typename TRIGGERTYPE>
   void BaseDAQ<TRIGGERTYPE>::deleteRingBufferFile() {
     try {
@@ -253,6 +169,8 @@ namespace ChimeraTK {
       std::cout << ex.what() << std::endl;
     }
   }
+
+  /********************************************************************************************************************/
 
   template<typename TRIGGERTYPE>
   void BaseDAQ<TRIGGERTYPE>::checkBufferOnFirstTrigger() {
@@ -289,6 +207,8 @@ namespace ChimeraTK {
     bufferNumber.close();
   }
 
+  /********************************************************************************************************************/
+
   template<typename TRIGGERTYPE>
   std::string BaseDAQ<TRIGGERTYPE>::nextBuffer() {
     std::vector<std::string> result;
@@ -314,6 +234,8 @@ namespace ChimeraTK {
     return filename;
   }
 
+  /********************************************************************************************************************/
+
   template<typename TRIGGERTYPE>
   void BaseDAQ<TRIGGERTYPE>::updateDAQPath() {
     if(enable == 0) {
@@ -325,6 +247,8 @@ namespace ChimeraTK {
       }
     }
   }
+
+  /********************************************************************************************************************/
 
   template<typename TRIGGERTYPE>
   bool BaseDAQ<TRIGGERTYPE>::maxEntriesReached() {
@@ -339,6 +263,8 @@ namespace ChimeraTK {
     return false;
   }
 
+  /********************************************************************************************************************/
+
   template<typename TRIGGERTYPE>
   void BaseDAQ<TRIGGERTYPE>::disableDAQ() {
     currentEntry = 0;
@@ -350,32 +276,11 @@ namespace ChimeraTK {
     currentBuffer.write();
   }
 
-  template<typename TRIGGERTYPE>
-  void BaseDAQ<TRIGGERTYPE>::findTagAndAppendToModule(
-      VirtualModule& virtualParent, const std::string& tag, bool, bool, bool negate, VirtualModule& root) const {
-    // Change behaviour to exclude the auto-generated inputs which are connected to the data sources. Otherwise those
-    // variables might get published twice to the control system, if findTag(".*") is used to connect the entire
-    // application to the control system.
-    // This is a temporary solution. In future, instead the inputs should be generated at the same place in the
-    // hierarchy as the source variable, and the connection should not be made by the module itself. It will be rather
-    // expected from the application to connect everything to a ControlSystemModule. addSource() should then also be
-    // removed, and the variable household of the application should instead be scanned for variables matching the
-    // given tag (see MicroDAQ envelope class). This currently does not yet work because of a missing concept:
-    // device variables currently do not know tags and hence it would not be possible to selectively add some device
-    // variables to the DAQ without adding the entire application.
-
-    struct MyVirtualModule : VirtualModule {
-      using VirtualModule::VirtualModule;
-      using VirtualModule::submodules;
-    };
-
-    MyVirtualModule temporary("temporary", "", ModuleType::ApplicationModule);
-    EntityOwner::findTagAndAppendToModule(temporary, R"(\*\*\*MicroDAQ-internal\*\*\*)", false, false, true, temporary);
-    for(auto& sm : temporary.submodules) {
-      sm.findTagAndAppendToModule(virtualParent, tag, false, false, negate, root);
-    }
-  }
+  /********************************************************************************************************************/
 
   INSTANTIATE_TEMPLATE_FOR_CHIMERATK_USER_TYPES_NO_VOID(MicroDAQ);
   INSTANTIATE_TEMPLATE_FOR_CHIMERATK_USER_TYPES_NO_VOID(BaseDAQ);
+
+  /********************************************************************************************************************/
+
 } // namespace ChimeraTK

--- a/src/MicroDAQHDF5.cc
+++ b/src/MicroDAQHDF5.cc
@@ -10,10 +10,9 @@
 #include "MicroDAQHDF5.h"
 
 namespace ChimeraTK {
-
-  /*********************************************************************************************************************/
-
   namespace detail {
+
+    /******************************************************************************************************************/
 
     template<typename TRIGGERTYPE>
     struct H5storage {
@@ -53,7 +52,7 @@ namespace ChimeraTK {
       std::vector<TransferElementID> _accessorsWithTrigger;
     };
 
-    /*********************************************************************************************************************/
+    /******************************************************************************************************************/
 
     template<typename TRIGGERTYPE>
     struct H5DataSpaceCreator {
@@ -102,7 +101,7 @@ namespace ChimeraTK {
 
   } // namespace detail
 
-  /*********************************************************************************************************************/
+  /********************************************************************************************************************/
 
   template<typename TRIGGERTYPE>
   void HDF5DAQ<TRIGGERTYPE>::mainLoop() {
@@ -116,7 +115,7 @@ namespace ChimeraTK {
         BaseDAQ<TRIGGERTYPE>::_accessorListMap.table, detail::H5DataSpaceCreator<TRIGGERTYPE>(storage));
 
     // add trigger
-    storage._accessorsWithTrigger.push_back(BaseDAQ<TRIGGERTYPE>::triggerGroup.trigger.getId());
+    storage._accessorsWithTrigger.push_back(BaseDAQ<TRIGGERTYPE>::trigger.getId());
 
     // sort group list and make unique to make sure lower levels get created first
     storage.groupList.sort();
@@ -134,7 +133,7 @@ namespace ChimeraTK {
     }
   }
 
-  /*********************************************************************************************************************/
+  /********************************************************************************************************************/
 
   namespace detail {
 
@@ -201,7 +200,7 @@ namespace ChimeraTK {
       }
     }
 
-    /*********************************************************************************************************************/
+    /******************************************************************************************************************/
 
     template<typename TRIGGERTYPE>
     struct H5DataWriter {
@@ -245,7 +244,7 @@ namespace ChimeraTK {
       H5storage<TRIGGERTYPE>& _storage;
     };
 
-    /*********************************************************************************************************************/
+    /******************************************************************************************************************/
 
     template<typename TRIGGERTYPE>
     template<typename UserType>
@@ -263,7 +262,7 @@ namespace ChimeraTK {
       dataset.write(buffer.data(), H5::PredType::NATIVE_FLOAT);
     }
 
-    /*********************************************************************************************************************/
+    /******************************************************************************************************************/
 
     template<typename TRIGGERTYPE>
     void H5storage<TRIGGERTYPE>::writeData() {
@@ -293,7 +292,7 @@ namespace ChimeraTK {
       boost::fusion::for_each(_owner->BaseDAQ<TRIGGERTYPE>::_accessorListMap.table, H5DataWriter<TRIGGERTYPE>(*this));
     }
 
-    /*********************************************************************************************************************/
+    /******************************************************************************************************************/
 
   } // namespace detail
 

--- a/src/MicroDAQHDF5.cc
+++ b/src/MicroDAQHDF5.cc
@@ -5,9 +5,9 @@
  *      Author: Klaus Zenker (HZDR)
  */
 
-#include <H5Cpp.h>
-
 #include "MicroDAQHDF5.h"
+
+#include <H5Cpp.h>
 
 namespace ChimeraTK {
   namespace detail {
@@ -154,7 +154,7 @@ namespace ChimeraTK {
 
         // open file
         try {
-          outFile = H5::H5File((_owner->_daqPath / filename).c_str(), H5F_ACC_TRUNC);
+          outFile.openFile((_owner->_daqPath / filename).c_str(), H5F_ACC_TRUNC);
         }
         catch(H5::FileIException&) {
           return;

--- a/src/MicroDAQROOT.cc
+++ b/src/MicroDAQROOT.cc
@@ -18,6 +18,8 @@ namespace ChimeraTK {
 
   namespace detail {
 
+    /******************************************************************************************************************/
+
     template<typename TRIGGERTYPE>
     struct ROOTstorage {
       ROOTstorage(RootDAQ<TRIGGERTYPE>* owner) : outFile(nullptr), tree(nullptr), _owner(owner) {}
@@ -66,6 +68,8 @@ namespace ChimeraTK {
        */
       std::vector<TransferElementID> _accessorsWithTrigger;
     };
+
+    /******************************************************************************************************************/
 
     template<typename TRIGGERTYPE>
     struct ROOTDataSpaceCreator {
@@ -130,6 +134,8 @@ namespace ChimeraTK {
       ROOTstorage<TRIGGERTYPE>& _storage;
     };
 
+    /******************************************************************************************************************/
+
     template<typename TRIGGERTYPE>
     struct ROOTTreeCreator {
       ROOTTreeCreator(ROOTstorage<TRIGGERTYPE>& storage, const std::string& name) : _storage(storage), _name(name) {}
@@ -159,6 +165,8 @@ namespace ChimeraTK {
       ROOTstorage<TRIGGERTYPE>& _storage;
       std::string _name;
     };
+
+    /******************************************************************************************************************/
 
     template<typename TRIGGERTYPE>
     struct ROOTDataWriter {
@@ -191,6 +199,8 @@ namespace ChimeraTK {
 
       ROOTstorage<TRIGGERTYPE>& _storage;
     };
+
+    /******************************************************************************************************************/
 
     template<typename TRIGGERTYPE>
     void ROOTstorage<TRIGGERTYPE>::processTrigger() {
@@ -260,6 +270,8 @@ namespace ChimeraTK {
 
   } // namespace detail
 
+  /********************************************************************************************************************/
+
   template<typename TRIGGERTYPE>
   void RootDAQ<TRIGGERTYPE>::mainLoop() {
     std::cout << "Initializing ROOTDAQ system..." << std::endl;
@@ -272,7 +284,7 @@ namespace ChimeraTK {
         BaseDAQ<TRIGGERTYPE>::_accessorListMap.table, detail::ROOTDataSpaceCreator<TRIGGERTYPE>(storage));
 
     // add trigger
-    storage._accessorsWithTrigger.push_back(BaseDAQ<TRIGGERTYPE>::triggerGroup.trigger.getId());
+    storage._accessorsWithTrigger.push_back(BaseDAQ<TRIGGERTYPE>::trigger.getId());
 
     // sort group list and make unique to make sure lower levels get created first
     storage.groupList.sort();
@@ -290,6 +302,10 @@ namespace ChimeraTK {
     }
   }
 
+  /********************************************************************************************************************/
+
   INSTANTIATE_TEMPLATE_FOR_CHIMERATK_USER_TYPES_NO_VOID(RootDAQ);
+
+  /********************************************************************************************************************/
 
 } // namespace ChimeraTK

--- a/test/Dummy.h
+++ b/test/Dummy.h
@@ -14,12 +14,16 @@
 typedef boost::mpl::list<int8_t, uint8_t, int16_t, uint16_t, int32_t, uint32_t, float, double, bool, std::string>
     test_types;
 
+/********************************************************************************************************************/
+
 template<typename UserType>
 struct Dummy : public ChimeraTK::ApplicationModule {
   using ChimeraTK::ApplicationModule::ApplicationModule;
+
   ChimeraTK::ScalarOutput<UserType> out{this, "out", "", "Dummy output", {"DAQ"}};
   ChimeraTK::ScalarOutput<int> outTrigger{this, "outTrigger", "", "Dummy output"};
   ChimeraTK::ScalarPushInput<int> trigger{this, "trigger", "", "Trigger", {}};
+
   void mainLoop() override {
     out = 0;
     // This also writes outTrigger!
@@ -31,6 +35,8 @@ struct Dummy : public ChimeraTK::ApplicationModule {
     }
   }
 };
+
+/********************************************************************************************************************/
 
 template<>
 struct Dummy<std::string> : public ChimeraTK::ApplicationModule {
@@ -51,6 +57,8 @@ struct Dummy<std::string> : public ChimeraTK::ApplicationModule {
     }
   }
 };
+
+/********************************************************************************************************************/
 
 template<>
 struct Dummy<bool> : public ChimeraTK::ApplicationModule {
@@ -73,6 +81,8 @@ struct Dummy<bool> : public ChimeraTK::ApplicationModule {
   }
 };
 
+/********************************************************************************************************************/
+
 template<typename UserType>
 struct DummyArray : public ChimeraTK::ApplicationModule {
   using ChimeraTK::ApplicationModule::ApplicationModule;
@@ -92,6 +102,8 @@ struct DummyArray : public ChimeraTK::ApplicationModule {
     }
   }
 };
+
+/********************************************************************************************************************/
 
 template<>
 struct DummyArray<std::string> : public ChimeraTK::ApplicationModule {
@@ -113,6 +125,8 @@ struct DummyArray<std::string> : public ChimeraTK::ApplicationModule {
   }
 };
 
+/********************************************************************************************************************/
+
 template<>
 struct DummyArray<bool> : public ChimeraTK::ApplicationModule {
   using ChimeraTK::ApplicationModule::ApplicationModule;
@@ -133,35 +147,4 @@ struct DummyArray<bool> : public ChimeraTK::ApplicationModule {
   }
 };
 
-/**
- * Define a test app to test the MicroDAQModule.
- */
-struct DeviceDummyApp : public ChimeraTK::Application {
-  DeviceDummyApp(const std::string& configFile) : Application("test") {
-    char temName[] = "/tmp/uDAQ.XXXXXX";
-    char* dir_name = mkdtemp(temName);
-    dir = std::string(dir_name);
-    // new fresh directory
-    boost::filesystem::create_directory(dir);
-    config.reset(new ChimeraTK::ConfigReader{this, "Configuration", configFile});
-    daq = ChimeraTK::MicroDAQ<int>{
-        this, "MicroDAQ", "DAQ module", "DAQ", "/Dummy/outTrigger", ChimeraTK::HierarchyModifier::none};
-  }
-  ~DeviceDummyApp() override { shutdown(); }
-
-  std::string dir;
-  // somehow without an module the application does not start...
-  Dummy<int32_t> module{this, "Dummy", "Module used as trigger"};
-  std::unique_ptr<ChimeraTK::ConfigReader> config;
-  ChimeraTK::ConnectingDeviceModule dev{this, "Dummy", "/Dummy/outTrigger"};
-  ChimeraTK::MicroDAQ<int> daq;
-  void defineConnections() override {
-    ChimeraTK::ControlSystemModule cs;
-    findTag(".*").connectTo(cs);
-    daq.addDeviceModule(dev.getDeviceModule());
-  }
-  void initialise() override {
-    Application::initialise();
-    dumpConnections();
-  }
-};
+/********************************************************************************************************************/

--- a/test/Dummy.h
+++ b/test/Dummy.h
@@ -16,6 +16,29 @@ typedef boost::mpl::list<int8_t, uint8_t, int16_t, uint16_t, int32_t, uint32_t, 
 
 /********************************************************************************************************************/
 
+struct DummyWithTag : public ChimeraTK::ApplicationModule {
+  DummyWithTag(ChimeraTK::ModuleGroup* module, const std::string& name, const std::string& description,
+      const std::string& tag = "DAQ")
+  : ChimeraTK::ApplicationModule(module, name, description), out(this, "out", "", "Dummy output", {tag}){};
+
+  ChimeraTK::ScalarOutput<int> out;
+  ChimeraTK::ScalarOutput<int> outTrigger{this, "outTrigger", "", "Dummy output"};
+  ChimeraTK::ScalarPushInput<int> trigger{this, "trigger", "", "Trigger", {}};
+
+  void mainLoop() override {
+    out = 0;
+    // This also writes outTrigger!
+    writeAll();
+    while(true) {
+      trigger.read();
+      out = out + 1;
+      writeAll();
+    }
+  }
+};
+
+/********************************************************************************************************************/
+
 template<typename UserType>
 struct Dummy : public ChimeraTK::ApplicationModule {
   using ChimeraTK::ApplicationModule::ApplicationModule;

--- a/test/testArrayMicroDAQ.C
+++ b/test/testArrayMicroDAQ.C
@@ -68,7 +68,7 @@ myMap m(boost::fusion::make_pair<int8_t>(0), boost::fusion::make_pair<uint8_t>(0
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(test_dummy_array, T, test_types) {
   testAppArray<T> app;
-  ChimeraTK::TestFacility tf;
+  ChimeraTK::TestFacility tf(app);
   tf.setScalarDefault("/MicroDAQ/nTriggersPerFile", (uint32_t)2);
   tf.setScalarDefault("/MicroDAQ/nMaxFiles", (uint32_t)5);
   tf.setScalarDefault("/MicroDAQ/activate", (ChimeraTK::Boolean)1);
@@ -153,7 +153,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_dummy_array, T, test_types) {
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(test_decimation, T, test_types) {
   testAppArray<T> app(2, 5);
-  ChimeraTK::TestFacility tf;
+  ChimeraTK::TestFacility tf(app);
   tf.setScalarDefault("/MicroDAQ/nTriggersPerFile", (uint32_t)2);
   tf.setScalarDefault("/MicroDAQ/nMaxFiles", (uint32_t)5);
   tf.setScalarDefault("/MicroDAQ/activate", (ChimeraTK::Boolean)1);

--- a/test/testArrayMicroDAQ.C
+++ b/test/testArrayMicroDAQ.C
@@ -5,28 +5,24 @@
  *      Author: Klaus Zenker (HZDR)
  */
 
-//#define BOOST_TEST_DYN_LINK
+// #define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE MicroDAQTest
 
-#include <fstream>
-#include <algorithm>
+#include "ChimeraTK/ApplicationCore/TestFacility.h"
+#include "data_types.h"
+#include "Dummy.h"
+#include "MicroDAQROOT.h"
+#include "TChain.h"
 
 #include <boost/algorithm/string.hpp>
 #include <boost/filesystem.hpp>
+#include <boost/fusion/container/map.hpp>
 #include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <boost/thread.hpp>
 
-#include "ChimeraTK/ApplicationCore/TestFacility.h"
-#include "ChimeraTK/ApplicationCore/ControlSystemModule.h"
-
-#include "MicroDAQROOT.h"
-#include "data_types.h"
-#include "Dummy.h"
-
-#include "TChain.h"
-
-#include <boost/test/unit_test.hpp>
-#include <boost/fusion/container/map.hpp>
+#include <algorithm>
+#include <fstream>
 using namespace boost::unit_test_framework;
 
 /**
@@ -41,8 +37,11 @@ struct testAppArray : public ChimeraTK::Application {
     dir = std::string(dir_name);
     // new fresh directory
     boost::filesystem::create_directory(dir);
+
+    // add source
+    daq.addSource("/Dummy", "DAQ");
   }
-  ~testAppArray() { shutdown(); }
+  ~testAppArray() override { shutdown(); }
 
   const uint32_t _decimation;
   const uint32_t _decimationThreshold;
@@ -51,15 +50,8 @@ struct testAppArray : public ChimeraTK::Application {
 
   DummyArray<UserType> module{this, "Dummy", "Dummy module"};
 
-  ChimeraTK::RootDAQ<int> daq{this, "MicroDAQ", "Test", _decimation, _decimationThreshold,
-      ChimeraTK::HierarchyModifier::none, {}, "/Dummy/outTrigger", "test"};
-
-  void defineConnections() override {
-    daq.addSource(module.findTag("DAQ"), "DAQ");
-    ChimeraTK::ControlSystemModule cs;
-    findTag(".*").connectTo(cs);
-    dumpConnections();
-  }
+  ChimeraTK::RootDAQ<int> daq{
+      this, "MicroDAQ", "Test", _decimation, _decimationThreshold, {}, "/Dummy/outTrigger", "test"};
 };
 
 typedef boost::fusion::map<boost::fusion::pair<int8_t, size_t>, boost::fusion::pair<uint8_t, size_t>,
@@ -103,37 +95,37 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_dummy_array, T, test_types) {
   if(t == 0) {
     arr = as.get();
     auto p = as.get();
-    ch->SetBranchAddress("DAQ.out", &p);
+    ch->SetBranchAddress("Dummy.out", &p);
   }
   else if(t == 1) {
     arr = ai.get();
     auto p = ai.get();
-    ch->SetBranchAddress("DAQ.out", &p);
+    ch->SetBranchAddress("Dummy.out", &p);
   }
   else if(t == 2) {
     arr = al.get();
     auto p = al.get();
-    ch->SetBranchAddress("DAQ.out", &p);
+    ch->SetBranchAddress("Dummy.out", &p);
   }
   else if(t == 3) {
     arr = af.get();
     auto p = af.get();
-    ch->SetBranchAddress("DAQ.out", &p);
+    ch->SetBranchAddress("Dummy.out", &p);
   }
   else if(t == 4) {
     arr = ad.get();
     auto p = ad.get();
-    ch->SetBranchAddress("DAQ.out", &p);
+    ch->SetBranchAddress("Dummy.out", &p);
   }
   else if(t == 5) {
     arr = ac.get();
     auto p = ac.get();
-    ch->SetBranchAddress("DAQ.out", &p);
+    ch->SetBranchAddress("Dummy.out", &p);
   }
   else if(t == 6) {
     arr = astr.get();
     auto p = astr.get();
-    ch->SetBranchAddress("DAQ.out", &p);
+    ch->SetBranchAddress("Dummy.out", &p);
   }
   ch->GetEvent(4);
   if constexpr(std::is_same<T, bool>::value) {
@@ -187,37 +179,37 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_decimation, T, test_types) {
   if(t == 0) {
     arr = as.get();
     auto p = as.get();
-    ch->SetBranchAddress("DAQ.out", &p);
+    ch->SetBranchAddress("Dummy.out", &p);
   }
   else if(t == 1) {
     arr = ai.get();
     auto p = ai.get();
-    ch->SetBranchAddress("DAQ.out", &p);
+    ch->SetBranchAddress("Dummy.out", &p);
   }
   else if(t == 2) {
     arr = al.get();
     auto p = al.get();
-    ch->SetBranchAddress("DAQ.out", &p);
+    ch->SetBranchAddress("Dummy.out", &p);
   }
   else if(t == 3) {
     arr = af.get();
     auto p = af.get();
-    ch->SetBranchAddress("DAQ.out", &p);
+    ch->SetBranchAddress("Dummy.out", &p);
   }
   else if(t == 4) {
     arr = ad.get();
     auto p = ad.get();
-    ch->SetBranchAddress("DAQ.out", &p);
+    ch->SetBranchAddress("Dummy.out", &p);
   }
   else if(t == 5) {
     arr = ac.get();
     auto p = ac.get();
-    ch->SetBranchAddress("DAQ.out", &p);
+    ch->SetBranchAddress("Dummy.out", &p);
   }
   else if(t == 6) {
     arr = astr.get();
     auto p = astr.get();
-    ch->SetBranchAddress("DAQ.out", &p);
+    ch->SetBranchAddress("Dummy.out", &p);
   }
   ch->GetEvent(1);
   // array is 1,3,5,7,9

--- a/test/testDevice_HDF5.C
+++ b/test/testDevice_HDF5.C
@@ -31,41 +31,8 @@ using namespace H5;
 using namespace boost::unit_test_framework;
 #undef BOOST_NO_EXCEPTIONS
 
-/********************************************************************************************************************/
-
-/**
- * Define a test app to test adding device modules to the MicroDAQ module
- */
-struct DeviceDummyApp : public ChimeraTK::Application {
-  DeviceDummyApp() : Application("test") {
-    // cleanup from previous run
-    char temName[] = "/tmp/uDAQ.XXXXXX";
-    char* dir_name = mkdtemp(temName);
-    dir = std::string(dir_name);
-
-    // new fresh directory
-    boost::filesystem::create_directory(dir);
-
-    // add device as source
-    daq.addDeviceModule(dev);
-  }
-  ~DeviceDummyApp() override { shutdown(); }
-
-  ChimeraTK::SetDMapFilePath dmap{"dummy.dmap"};
-
-  std::string dir;
-
-  // somehow without an module the application does not start...
-  Dummy<int32_t> module{this, "Dummy", "Module used as trigger"};
-  ChimeraTK::ConfigReader config{this, "Configuration", "device_test_HDF5.xml"};
-  ChimeraTK::DeviceModule dev{this, "Dummy", "/Dummy/outTrigger"};
-  ChimeraTK::MicroDAQ<int> daq{this, "MicroDAQ", "DAQ module", "DAQ", "/Dummy/outTrigger"};
-};
-
-/********************************************************************************************************************/
-
 BOOST_AUTO_TEST_CASE(test_device_daq) {
-  DeviceDummyApp app;
+  DeviceDummyApp app{"device_test_HDF5.xml"};
 
   ChimeraTK::Device dev;
   dev.open("Dummy-Raw");
@@ -128,39 +95,8 @@ BOOST_AUTO_TEST_CASE(test_device_daq) {
 
 /********************************************************************************************************************/
 
-/**
- * Define a test app to test adding device modules with sub-module and prefix specification to the MicroDAQ module
- */
-struct PrefixDeviceDummyApp : public ChimeraTK::Application {
-  PrefixDeviceDummyApp() : Application("test") {
-    // cleanup from previous run
-    char temName[] = "/tmp/uDAQ.XXXXXX";
-    char* dir_name = mkdtemp(temName);
-    dir = std::string(dir_name);
-
-    // new fresh directory
-    boost::filesystem::create_directory(dir);
-
-    // add device as source
-    daq.addDeviceModule(dev, "/some/new/prefix", "/MyModule");
-  }
-  ~PrefixDeviceDummyApp() override { shutdown(); }
-
-  ChimeraTK::SetDMapFilePath dmap{"dummy.dmap"};
-
-  std::string dir;
-
-  // somehow without an module the application does not start...
-  Dummy<int32_t> module{this, "Dummy", "Module used as trigger"};
-  ChimeraTK::ConfigReader config{this, "Configuration", "device_test_HDF5.xml"};
-  ChimeraTK::DeviceModule dev{this, "Dummy", "/Dummy/outTrigger"};
-  ChimeraTK::MicroDAQ<int> daq{this, "MicroDAQ", "DAQ module", "DAQ", "/Dummy/outTrigger"};
-};
-
-/********************************************************************************************************************/
-
 BOOST_AUTO_TEST_CASE(test_device_daq_with_prefix) {
-  PrefixDeviceDummyApp app;
+  DeviceDummyApp app{"device_test_HDF5.xml", "/some/new/prefix", "MyModule"};
 
   ChimeraTK::Device dev;
   dev.open("Dummy-Raw");

--- a/test/testDevice_HDF5.C
+++ b/test/testDevice_HDF5.C
@@ -7,42 +7,77 @@
 
 #define BOOST_TEST_MODULE MicroDAQDeviceTest
 
-#include <memory>
-
-#include "ChimeraTK/ApplicationCore/TestFacility.h"
-#include "ChimeraTK/ApplicationCore/ControlSystemModule.h"
-#include "ChimeraTK/ApplicationCore/DeviceModule.h"
-#include "ChimeraTK/ApplicationCore/ScalarAccessor.h"
-
-#include "H5Cpp.h"
 #include "Dummy.h"
-
+#include "H5Cpp.h"
 #include "MicroDAQ.h"
 
-#include <boost/test/included/unit_test.hpp>
-#include <boost/thread.hpp>
-#include <boost/format.hpp>
+#include <ChimeraTK/ApplicationCore/DeviceModule.h>
+#include <ChimeraTK/ApplicationCore/ScalarAccessor.h>
+#include <ChimeraTK/ApplicationCore/TestFacility.h>
+
 #include <boost/filesystem.hpp>
-#include <boost/test/unit_test.hpp>
+#include <boost/format.hpp>
 #include <boost/fusion/container/map.hpp>
-using namespace boost::unit_test_framework;
+#include <boost/thread.hpp>
+
+#include <memory>
 
 #ifndef H5_NO_NAMESPACE
 using namespace H5;
 #endif
 
+#define BOOST_NO_EXCEPTIONS
+#include <boost/test/included/unit_test.hpp>
+using namespace boost::unit_test_framework;
+#undef BOOST_NO_EXCEPTIONS
+
+/********************************************************************************************************************/
+
+/**
+ * Define a test app to test adding device modules to the MicroDAQ module
+ */
+struct DeviceDummyApp : public ChimeraTK::Application {
+  DeviceDummyApp() : Application("test") {
+    // cleanup from previous run
+    char temName[] = "/tmp/uDAQ.XXXXXX";
+    char* dir_name = mkdtemp(temName);
+    dir = std::string(dir_name);
+
+    // new fresh directory
+    boost::filesystem::create_directory(dir);
+
+    // add device as source
+    daq.addDeviceModule(dev);
+  }
+  ~DeviceDummyApp() override { shutdown(); }
+
+  ChimeraTK::SetDMapFilePath dmap{"dummy.dmap"};
+
+  std::string dir;
+
+  // somehow without an module the application does not start...
+  Dummy<int32_t> module{this, "Dummy", "Module used as trigger"};
+  ChimeraTK::ConfigReader config{this, "Configuration", "device_test_HDF5.xml"};
+  ChimeraTK::DeviceModule dev{this, "Dummy", "/Dummy/outTrigger"};
+  ChimeraTK::MicroDAQ<int> daq{this, "MicroDAQ", "DAQ module", "DAQ", "/Dummy/outTrigger"};
+};
+
+/********************************************************************************************************************/
+
 BOOST_AUTO_TEST_CASE(test_device_daq) {
-  ChimeraTK::BackendFactory::getInstance().setDMapFilePath("dummy.dmap");
-  DeviceDummyApp app("device_test_HDF5.xml");
+  DeviceDummyApp app;
 
   ChimeraTK::Device dev;
   dev.open("Dummy-Raw");
   auto readback = dev.getScalarRegisterAccessor<int>("/MyModule/readback");
-  ChimeraTK::TestFacility tf;
-  tf.setScalarDefault("/MicroDAQ/nTriggersPerFile", (uint32_t)2);
-  tf.setScalarDefault("/MicroDAQ/nMaxFiles", (uint32_t)5);
-  tf.setScalarDefault("/MicroDAQ/activate", (ChimeraTK::Boolean)1);
+
+  ChimeraTK::TestFacility tf(app);
+
+  tf.setScalarDefault("/MicroDAQ/nTriggersPerFile", uint32_t(2));
+  tf.setScalarDefault("/MicroDAQ/nMaxFiles", uint32_t(5));
+  tf.setScalarDefault("/MicroDAQ/activate", ChimeraTK::Boolean(true));
   tf.setScalarDefault("/MicroDAQ/directory", app.dir);
+
   tf.runApplication();
 
   for(size_t j = 0; j < 9; j++) {
@@ -90,3 +125,100 @@ BOOST_AUTO_TEST_CASE(test_device_daq) {
   // remove currentBuffer and data0000.h5 to data0004.h5 and the directory uDAQ
   BOOST_CHECK_EQUAL(boost::filesystem::remove_all(app.dir), 7);
 }
+
+/********************************************************************************************************************/
+
+/**
+ * Define a test app to test adding device modules with sub-module and prefix specification to the MicroDAQ module
+ */
+struct PrefixDeviceDummyApp : public ChimeraTK::Application {
+  PrefixDeviceDummyApp() : Application("test") {
+    // cleanup from previous run
+    char temName[] = "/tmp/uDAQ.XXXXXX";
+    char* dir_name = mkdtemp(temName);
+    dir = std::string(dir_name);
+
+    // new fresh directory
+    boost::filesystem::create_directory(dir);
+
+    // add device as source
+    daq.addDeviceModule(dev, "/some/new/prefix", "/MyModule");
+  }
+  ~PrefixDeviceDummyApp() override { shutdown(); }
+
+  ChimeraTK::SetDMapFilePath dmap{"dummy.dmap"};
+
+  std::string dir;
+
+  // somehow without an module the application does not start...
+  Dummy<int32_t> module{this, "Dummy", "Module used as trigger"};
+  ChimeraTK::ConfigReader config{this, "Configuration", "device_test_HDF5.xml"};
+  ChimeraTK::DeviceModule dev{this, "Dummy", "/Dummy/outTrigger"};
+  ChimeraTK::MicroDAQ<int> daq{this, "MicroDAQ", "DAQ module", "DAQ", "/Dummy/outTrigger"};
+};
+
+/********************************************************************************************************************/
+
+BOOST_AUTO_TEST_CASE(test_device_daq_with_prefix) {
+  PrefixDeviceDummyApp app;
+
+  ChimeraTK::Device dev;
+  dev.open("Dummy-Raw");
+  auto readback = dev.getScalarRegisterAccessor<int>("/MyModule/readback");
+
+  ChimeraTK::TestFacility tf(app);
+
+  tf.setScalarDefault("/MicroDAQ/nTriggersPerFile", uint32_t(2));
+  tf.setScalarDefault("/MicroDAQ/nMaxFiles", uint32_t(5));
+  tf.setScalarDefault("/MicroDAQ/activate", ChimeraTK::Boolean(true));
+  tf.setScalarDefault("/MicroDAQ/directory", app.dir);
+
+  tf.runApplication();
+
+  for(size_t j = 0; j < 9; j++) {
+    // initial value is already written to file at this point - so the next entry should be 1 and not 0!
+    // in the dummy this is realised by calling out = out+1
+    tf.writeScalar("/MyModule/actuator", (int)(j + 1));
+    readback = (int)(j + 1);
+    readback.write();
+    tf.writeScalar("/Dummy/trigger", (int)j);
+    tf.stepApplication();
+  }
+
+  // Only check second DAQ file
+  boost::filesystem::path daqPath(app.dir);
+  boost::filesystem::path file;
+  if(boost::filesystem::exists(daqPath)) {
+    if(boost::filesystem::is_directory(daqPath)) {
+      for(auto i = boost::filesystem::directory_iterator(daqPath); i != boost::filesystem::directory_iterator(); i++) {
+        // look for file *buffer0001.h5 -> that file includes data out=3 and out=4
+        std::string match = (boost::format("buffer%04d%s") % 1 % ".h5").str();
+        if(boost::filesystem::canonical(i->path()).string().find(match) != std::string::npos) {
+          file = i->path();
+        }
+      }
+    }
+  }
+
+  // Only check first trigger
+  H5File h5file(file.string().c_str(), H5F_ACC_RDONLY);
+  Group gr = h5file.openGroup("/");
+  auto event = gr.openGroup(gr.getObjnameByIdx(0).c_str());
+  Group dataGroup[2] = {event.openGroup("Dummy"), event.openGroup("some").openGroup("new").openGroup("prefix")};
+  DataSet datasets[3] = {
+      dataGroup[0].openDataSet("out"), dataGroup[1].openDataSet("actuator"), dataGroup[1].openDataSet("readback")};
+  DataSpace filespaces[3] = {datasets[0].getSpace(), datasets[1].getSpace(), datasets[2].getSpace()};
+  hsize_t dims[1]; // dataset dimensions
+  int rank = filespaces[0].getSimpleExtentDims(dims);
+
+  DataSpace mspace1(rank, dims);
+  std::vector<float> v(1);
+  for(size_t i = 3; i < 2; i++) {
+    datasets[i].read(&v[0], PredType::NATIVE_FLOAT, mspace1, filespaces[i]);
+    BOOST_CHECK_EQUAL(v.at(0), 2);
+  }
+  // remove currentBuffer and data0000.h5 to data0004.h5 and the directory uDAQ
+  BOOST_CHECK_EQUAL(boost::filesystem::remove_all(app.dir), 7);
+}
+
+/********************************************************************************************************************/

--- a/test/testDevice_ROOT.C
+++ b/test/testDevice_ROOT.C
@@ -7,26 +7,22 @@
 
 #define BOOST_TEST_MODULE MicroDAQDeviceTest
 
-#include <memory>
-
-#include "ChimeraTK/ApplicationCore/TestFacility.h"
-#include "ChimeraTK/ApplicationCore/ControlSystemModule.h"
 #include "ChimeraTK/ApplicationCore/DeviceModule.h"
 #include "ChimeraTK/ApplicationCore/ScalarAccessor.h"
-
-#include "MicroDAQROOT.h"
-
-#include "H5Cpp.h"
+#include "ChimeraTK/ApplicationCore/TestFacility.h"
 #include "Dummy.h"
-
+#include "H5Cpp.h"
+#include "MicroDAQROOT.h"
 #include "TChain.h"
 
-#include <boost/test/included/unit_test.hpp>
-#include <boost/thread.hpp>
-#include <boost/format.hpp>
 #include <boost/filesystem.hpp>
-#include <boost/test/unit_test.hpp>
+#include <boost/format.hpp>
 #include <boost/fusion/container/map.hpp>
+#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
+#include <boost/thread.hpp>
+
+#include <memory>
 using namespace boost::unit_test_framework;
 
 BOOST_AUTO_TEST_CASE(test_device_daq) {

--- a/test/testDevice_ROOT.C
+++ b/test/testDevice_ROOT.C
@@ -32,7 +32,7 @@ BOOST_AUTO_TEST_CASE(test_device_daq) {
   ChimeraTK::Device dev;
   dev.open("Dummy-Raw");
   auto readback = dev.getScalarRegisterAccessor<int>("/MyModule/readback");
-  ChimeraTK::TestFacility tf;
+  ChimeraTK::TestFacility tf(app);
   tf.setScalarDefault("/MicroDAQ/nTriggersPerFile", (uint32_t)2);
   tf.setScalarDefault("/MicroDAQ/nMaxFiles", (uint32_t)5);
   tf.setScalarDefault("/MicroDAQ/activate", (ChimeraTK::Boolean)1);

--- a/test/testDevice_ROOT.C
+++ b/test/testDevice_ROOT.C
@@ -61,3 +61,40 @@ BOOST_AUTO_TEST_CASE(test_device_daq) {
   BOOST_CHECK_EQUAL(data[2], 5);
   BOOST_CHECK_EQUAL(boost::filesystem::remove_all(app.dir), 7);
 }
+
+BOOST_AUTO_TEST_CASE(test_device_daq_with_prefix) {
+  ChimeraTK::BackendFactory::getInstance().setDMapFilePath("dummy.dmap");
+  DeviceDummyApp app("device_test_ROOT.xml", "/some/new/prefix", "MyModule");
+
+  ChimeraTK::Device dev;
+  dev.open("Dummy-Raw");
+  auto readback = dev.getScalarRegisterAccessor<int>("/MyModule/readback");
+  ChimeraTK::TestFacility tf(app);
+  tf.setScalarDefault("/MicroDAQ/nTriggersPerFile", (uint32_t)2);
+  tf.setScalarDefault("/MicroDAQ/nMaxFiles", (uint32_t)5);
+  tf.setScalarDefault("/MicroDAQ/activate", (ChimeraTK::Boolean)1);
+  tf.setScalarDefault("/MicroDAQ/directory", app.dir);
+  tf.runApplication();
+  for(size_t j = 0; j < 9; j++) {
+    // initial value is already written to file at this point - so the next entry should be 1 and not 0!
+    // in the dummy this is realised by calling out = out+1
+    tf.writeScalar("/MyModule/actuator", (int)(j + 1));
+    readback = (int)(j + 1);
+    readback.write();
+    tf.writeScalar("/Dummy/trigger", (int)j);
+    tf.stepApplication();
+  }
+  TChain* ch = new TChain("data");
+  ch->Add((app.dir + "/*.root").c_str());
+  BOOST_CHECK_NE(0, ch->GetEntries());
+  int data[3];
+  ch->SetBranchAddress("some.new.prefix.actuator", &data[0]);
+  ch->SetBranchAddress("some.new.prefix.readback", &data[1]);
+  ch->SetBranchAddress("Dummy.out", &data[2]);
+  ch->GetEvent(5);
+
+  BOOST_CHECK_EQUAL(data[0], 5);
+  BOOST_CHECK_EQUAL(data[1], 5);
+  BOOST_CHECK_EQUAL(data[2], 5);
+  BOOST_CHECK_EQUAL(boost::filesystem::remove_all(app.dir), 7);
+}

--- a/test/testScalarMicroDAQ.C
+++ b/test/testScalarMicroDAQ.C
@@ -50,7 +50,7 @@ struct testApp : public ChimeraTK::Application {
 
 BOOST_AUTO_TEST_CASE(test_directory_access) {
   testApp<int32_t> app;
-  ChimeraTK::TestFacility tf;
+  ChimeraTK::TestFacility tf(app);
   tf.setScalarDefault("/MicroDAQ/nTriggersPerFile", (uint32_t)2);
   tf.setScalarDefault("/MicroDAQ/nMaxFiles", (uint32_t)5);
   tf.setScalarDefault("/MicroDAQ/activate", (ChimeraTK::Boolean)1);
@@ -64,7 +64,7 @@ BOOST_AUTO_TEST_CASE(test_directory_access) {
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(test_dummy, T, test_types) {
   testApp<T> app;
-  ChimeraTK::TestFacility tf;
+  ChimeraTK::TestFacility tf(app);
   tf.setScalarDefault("/MicroDAQ/nTriggersPerFile", (uint32_t)2);
   tf.setScalarDefault("/MicroDAQ/nMaxFiles", (uint32_t)5);
   tf.setScalarDefault("/MicroDAQ/activate", (ChimeraTK::Boolean)1);

--- a/test/testScalarMicroDAQ.C
+++ b/test/testScalarMicroDAQ.C
@@ -5,27 +5,23 @@
  *      Author: Klaus Zenker (HZDR)
  */
 
-//#define BOOST_TEST_DYN_LINK
+// #define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE MicroDAQTest
 
-#include <fstream>
+#include "ChimeraTK/ApplicationCore/TestFacility.h"
+#include "Dummy.h"
+#include "MicroDAQROOT.h"
+#include "TChain.h"
 #include <type_traits>
 
 #include <boost/algorithm/string.hpp>
 #include <boost/filesystem.hpp>
+#include <boost/fusion/container/map.hpp>
 #include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <boost/thread.hpp>
 
-#include "ChimeraTK/ApplicationCore/TestFacility.h"
-#include "ChimeraTK/ApplicationCore/ControlSystemModule.h"
-
-#include "MicroDAQROOT.h"
-#include "Dummy.h"
-
-#include "TChain.h"
-
-#include <boost/test/unit_test.hpp>
-#include <boost/fusion/container/map.hpp>
+#include <fstream>
 using namespace boost::unit_test_framework;
 
 /**
@@ -39,6 +35,9 @@ struct testApp : public ChimeraTK::Application {
     dir = std::string(dir_name);
     // new fresh directory
     boost::filesystem::create_directory(dir);
+
+    // add source
+    daq.addSource("/Dummy", "DAQ");
   }
   ~testApp() { shutdown(); }
 
@@ -46,15 +45,7 @@ struct testApp : public ChimeraTK::Application {
 
   Dummy<UserType> module{this, "Dummy", "Dummy module"};
 
-  ChimeraTK::RootDAQ<int> daq{
-      this, "MicroDAQ", "Test", 10, 1000, ChimeraTK::HierarchyModifier::none, {}, "/Dummy/outTrigger", "test"};
-
-  void defineConnections() override {
-    daq.addSource(module.findTag("DAQ"), "DAQ");
-    ChimeraTK::ControlSystemModule cs;
-    findTag(".*").connectTo(cs);
-    dumpConnections();
-  }
+  ChimeraTK::RootDAQ<int> daq{this, "MicroDAQ", "Test", 10, 1000, {}, "/Dummy/outTrigger", "test"};
 };
 
 BOOST_AUTO_TEST_CASE(test_directory_access) {
@@ -91,10 +82,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_dummy, T, test_types) {
   T* ptest = new T();
   T test;
   if constexpr(std::is_same<T, std::string>::value) {
-    ch->SetBranchAddress("DAQ.out", &ptest);
+    ch->SetBranchAddress("Dummy.out", &ptest);
   }
   else {
-    ch->SetBranchAddress("DAQ.out", &test);
+    ch->SetBranchAddress("Dummy.out", &test);
   }
   ch->GetEvent(4);
   if constexpr(std::is_same<T, bool>::value) {

--- a/test/test_HDF5.C
+++ b/test/test_HDF5.C
@@ -5,28 +5,24 @@
  *      Author: zenker
  */
 
-//#define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE MicroDAQTestHDF5
 
-#include <boost/filesystem.hpp>
-#include <boost/mpl/list.hpp>
-#include <boost/format.hpp>
-
-#include <string>
-#include <vector>
-#include "hdf5.h"
-#include <stdlib.h>
-#include <chrono>
-#include <thread>
-
+#include "Dummy.h"
 #include "H5Cpp.h"
-
-#include "ChimeraTK/ApplicationCore/TestFacility.h"
-#include "ChimeraTK/ApplicationCore/ControlSystemModule.h"
-
+#include "hdf5.h"
 #include "MicroDAQHDF5.h"
 
-#include "Dummy.h"
+#include <ChimeraTK/ApplicationCore/TestFacility.h>
+
+#include <boost/filesystem.hpp>
+#include <boost/format.hpp>
+#include <boost/mpl/list.hpp>
+
+#include <chrono>
+#include <cstdlib>
+#include <string>
+#include <thread>
+#include <vector>
 
 // this include must come last
 #define BOOST_NO_EXCEPTIONS
@@ -34,50 +30,57 @@
 using namespace boost::unit_test_framework;
 #undef BOOST_NO_EXCEPTIONS
 
+/********************************************************************************************************************/
+
 /**
  * Define a test app to test the MicroDAQModule.
  */
 template<typename UserType>
 struct testApp : public ChimeraTK::Application {
-  testApp() : Application("test") { // cleanup
+  testApp() : Application("test") {
+    // cleanup from previous runs
     char temName[] = "/tmp/uDAQ.XXXXXX";
     char* dir_name = mkdtemp(temName);
     dir = std::string(dir_name);
+
     // new fresh directory
     boost::filesystem::create_directory(dir);
+
+    // add source
+    daq.addSource("/Dummy", "DAQ");
   }
-  ~testApp() { shutdown(); }
+
+  ~testApp() override { shutdown(); }
 
   Dummy<UserType> module{this, "Dummy", "Dummy module"};
 
-  ChimeraTK::HDF5DAQ<int> daq{
-      this, "MicroDAQ", "Test of the MicroDAQ", 10, 1000, ChimeraTK::HierarchyModifier::none, {}, "/Dummy/outTrigger"};
+  ChimeraTK::HDF5DAQ<int> daq{this, "MicroDAQ", "Test of the MicroDAQ", 10, 1000, {}, "/Dummy/outTrigger"};
 
   std::string dir;
-
-  void defineConnections() override {
-    daq.addSource(module.findTag("DAQ"), "DAQ");
-    ChimeraTK::ControlSystemModule cs;
-    findTag(".*").connectTo(cs);
-
-    dumpConnections();
-  }
 };
+
+/********************************************************************************************************************/
 
 /**
  * Define a test app to test the MicroDAQModule.
  */
 template<typename UserType>
 struct testAppArray : public ChimeraTK::Application {
-  testAppArray(uint32_t decimation = 10, uint32_t decimationThreshold = 1000)
+  explicit testAppArray(uint32_t decimation = 10, uint32_t decimationThreshold = 1000)
   : Application("test"), _decimation(decimation), _decimationThreshold(decimationThreshold) {
+    // cleanup from previous runs
     char temName[] = "/tmp/uDAQ.XXXXXX";
     char* dir_name = mkdtemp(temName);
     dir = std::string(dir_name);
+
     // new fresh directory
     boost::filesystem::create_directory(dir);
+
+    // add source
+    daq.addSource("/Dummy", "DAQ");
   }
-  ~testAppArray() { shutdown(); }
+
+  ~testAppArray() override { shutdown(); }
 
   const uint32_t _decimation;
   const uint32_t _decimationThreshold;
@@ -86,28 +89,28 @@ struct testAppArray : public ChimeraTK::Application {
 
   std::string dir;
 
-  ChimeraTK::HDF5DAQ<int> daq{this, "MicroDAQ", "Test of the MicroDAQ", _decimation, _decimationThreshold,
-      ChimeraTK::HierarchyModifier::none, {}, "/Dummy/outTrigger"};
-  //  ChimeraTK::MicroDAQ<int> daq{this,"MicroDAQ","Test", 10, 1000};
-
-  void defineConnections() override {
-    daq.addSource(module.findTag("DAQ"), "DAQ");
-    ChimeraTK::ControlSystemModule cs;
-    findTag(".*").connectTo(cs);
-    dumpConnections();
-  }
+  ChimeraTK::HDF5DAQ<int> daq{
+      this, "MicroDAQ", "Test of the MicroDAQ", _decimation, _decimationThreshold, {}, "/Dummy/outTrigger"};
 };
+
+/********************************************************************************************************************/
 
 #ifndef H5_NO_NAMESPACE
 using namespace H5;
 #endif
 
+/********************************************************************************************************************/
+
 BOOST_AUTO_TEST_CASE_TEMPLATE(test_scalar, T, test_types) {
+  std::cout << "test_scalar<" << typeid(T).name() << ">" << std::endl;
+
   testApp<T> app;
-  ChimeraTK::TestFacility tf;
-  tf.setScalarDefault("/MicroDAQ/nTriggersPerFile", (uint32_t)2);
-  tf.setScalarDefault("/MicroDAQ/nMaxFiles", (uint32_t)5);
-  tf.setScalarDefault("/MicroDAQ/activate", (ChimeraTK::Boolean)1);
+  ChimeraTK::TestFacility tf(app);
+
+  tf.setScalarDefault("/MicroDAQ/nTriggersPerFile", uint32_t(2));
+  tf.setScalarDefault("/MicroDAQ/nMaxFiles", uint32_t(5));
+  tf.setScalarDefault("/MicroDAQ/activate", ChimeraTK::Boolean(true));
+
   tf.setScalarDefault("/MicroDAQ/directory", app.dir);
   tf.runApplication();
 
@@ -137,7 +140,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_scalar, T, test_types) {
   H5File h5file(file.string().c_str(), H5F_ACC_RDONLY);
   Group gr = h5file.openGroup("/");
   auto event = gr.openGroup(gr.getObjnameByIdx(0).c_str());
-  auto dataGroup = event.openGroup("DAQ");
+  auto dataGroup = event.openGroup("Dummy");
   DataSet dataset = dataGroup.openDataSet("out");
   DataSpace filespace = dataset.getSpace();
   hsize_t dims[1]; // dataset dimensions
@@ -156,12 +159,18 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_scalar, T, test_types) {
   BOOST_CHECK_EQUAL(boost::filesystem::remove_all(app.dir), 7);
 }
 
+/********************************************************************************************************************/
+
 BOOST_AUTO_TEST_CASE_TEMPLATE(test_array, T, test_types) {
+  std::cout << "test_array<" << typeid(T).name() << ">" << std::endl;
+
   testAppArray<T> app;
-  ChimeraTK::TestFacility tf;
-  tf.setScalarDefault("/MicroDAQ/nTriggersPerFile", (uint32_t)2);
-  tf.setScalarDefault("/MicroDAQ/nMaxFiles", (uint32_t)5);
-  tf.setScalarDefault("/MicroDAQ/activate", (ChimeraTK::Boolean)1);
+  ChimeraTK::TestFacility tf(app);
+
+  tf.setScalarDefault("/MicroDAQ/nTriggersPerFile", uint32_t(2));
+  tf.setScalarDefault("/MicroDAQ/nMaxFiles", uint32_t(5));
+  tf.setScalarDefault("/MicroDAQ/activate", ChimeraTK::Boolean(true));
+
   tf.setScalarDefault("/MicroDAQ/directory", app.dir);
   tf.runApplication();
 
@@ -190,7 +199,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_array, T, test_types) {
   H5File h5file(file.string().c_str(), H5F_ACC_RDONLY);
   Group gr = h5file.openGroup("/");
   auto event = gr.openGroup(gr.getObjnameByIdx(0).c_str());
-  auto dataGroup = event.openGroup("DAQ");
+  auto dataGroup = event.openGroup("Dummy");
   DataSet dataset = dataGroup.openDataSet("out");
   DataSpace filespace = dataset.getSpace();
   hsize_t dims[1]; // dataset dimensions
@@ -212,3 +221,5 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_array, T, test_types) {
   // remove currentBuffer and data0000.h5 to data0004.h5 and the directory uDAQ
   BOOST_CHECK_EQUAL(boost::filesystem::remove_all(app.dir), 7);
 }
+
+/********************************************************************************************************************/


### PR DESCRIPTION
This PR seeks to make the MicroDAQ module compatible with ApplicationCore 3.0. Some adjustments were necessary to the old-style API of the `BaseDAQ` interface, especially `BaseDAQ::addSource()` works now differently. Applications should be migrated to the "new" `MicroDAQ` class anyway.

I hope all use cases are covered. The tests are passing but they don't seem to be really complete.