### PR TITLE
Extract the include directory of ApplicationCore from the cmake target.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,8 @@ include(${CMAKE_SOURCE_DIR}/cmake/set_default_build_to_release.cmake)
 #______________________________________________________________________________
 #                                                                  Dependencies
 find_package(ChimeraTK-ApplicationCore 03.00 REQUIRED)
+# extract ApplicationCore include dir from the chimeraTK target - it is needed to build the ROOT dictionary
+get_target_property(ChimeraTK-ApplicationCore_INCLUDE_DIRS ChimeraTK::ChimeraTK-ApplicationCore INTERFACE_INCLUDE_DIRECTORIES)
 include_directories(SYSTEM ${ChimeraTK-ApplicationCore_INCLUDE_DIRS})
 find_package(Boost COMPONENTS date_time REQUIRED)
 


### PR DESCRIPTION
This information is used to build the ROOT dictionary, which requires a header file of ApplicationCore.