### PR TITLE
Do not throw exception if pvs are listed twice by the model.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ option(BUILD_TESTS "Build tests" ON)
 #                                                                       VERSION
 set(${PROJECT_NAME}_MAJOR_VERSION 03)
 set(${PROJECT_NAME}_MINOR_VERSION 00)
-set(${PROJECT_NAME}_PATCH_VERSION 02)
+set(${PROJECT_NAME}_PATCH_VERSION 03)
 include(${CMAKE_SOURCE_DIR}/cmake/set_version_numbers.cmake)
 include(${CMAKE_SOURCE_DIR}/cmake/set_default_flags.cmake)
 include(${CMAKE_SOURCE_DIR}/cmake/set_default_build_to_release.cmake)
@@ -20,7 +20,7 @@ include(${CMAKE_SOURCE_DIR}/cmake/set_default_build_to_release.cmake)
 
 #______________________________________________________________________________
 #                                                                  Dependencies
-find_package(ChimeraTK-ApplicationCore 03.00 REQUIRED)
+find_package(ChimeraTK-ApplicationCore 03.02 REQUIRED)
 # extract ApplicationCore include dir from the chimeraTK target - it is needed to build the ROOT dictionary
 get_target_property(ChimeraTK-ApplicationCore_INCLUDE_DIRS ChimeraTK::ChimeraTK-ApplicationCore INTERFACE_INCLUDE_DIRECTORIES)
 include_directories(SYSTEM ${ChimeraTK-ApplicationCore_INCLUDE_DIRS})

--- a/include/MicroDAQ.h
+++ b/include/MicroDAQ.h
@@ -284,7 +284,8 @@ namespace ChimeraTK {
 
     // check for name collision
     if(_overallVariableList.count(daqName) > 0) {
-      throw ChimeraTK::logic_error("MicroDAQ: DAQ name '" + daqName + "' already taken when adding PV '" + name + "'.");
+      // Can happen if a pv is added in the logical name mapping process twice, e.g. to use math plugin
+      return;
     }
     _overallVariableList.insert(daqName);
 


### PR DESCRIPTION
Simply add them only once.